### PR TITLE
Dev Workspace Panel — file browser, code viewer, git diff, remote agent support

### DIFF
--- a/changelog/version-0-0-13.md
+++ b/changelog/version-0-0-13.md
@@ -1,0 +1,50 @@
+# v0.0.13 — 2026-05-30
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- add download button to file tree — download files from remote agents to local device
+- fix empty code blocks — handle both string and object token formats from marked
+- fix undefined in code blocks — fallback to raw token when text is undefined
+- unified font scaling — chat bubbles, code viewer, markdown all share --stoa-msg-scale
+- hide console windows on git commands + add timeout to prevent zombie processes
+- auto-refresh workspace on agent activity — file tree and git diff update after message complete and tool steps
+- add git diff proxy for remote agents, auto-fetch on room join, badge on Git tab
+- fix markdown h1 font-size 28px → 30px per design spec
+- bump CLIENT_VERSION to 0.2.35
+- add syntax highlighting to code viewer + modified file indicators in file tree
+- audit round 4 fixes — res.ok checks on actor lang, rescan, force-update
+- audit round 3 fixes — res.ok checks, missing indexes, rooms query LIMIT
+- audit round 2 fixes — error handling, docs accuracy, top-level catch 500
+- audit fixes — close path traversal vulnerabilities, add error checks, document workspace panel
+- fix duplicate tab on image open — preserve original path in proxy response
+- fix file tree click using wrong path — use absolute path from tree root for remote files
+- fix empty files not rendering — use loaded flag instead of content truthiness
+- auto force-update agents on connect when version is outdated
+- bump CLIENT_VERSION to 0.2.34 — trigger auto-update for binary file proxy
+- fix remote file viewing — proxy text and binary (base64) through agent WebSocket
+- fix absolute path tree overwritten by workdir — avoid duplicate file_list request
+- support absolute paths from chat — browse any directory on agent's machine
+- fix remote file browsing — check fs.existsSync before assuming local read success
+- fix directory path click — force file_list request, add error logging
+- bump CLIENT_VERSION to 0.2.33 — trigger auto-update for remote agents
+- fix missing closing brace in file_read handler causing server crash
+- proxy file operations through agent WebSocket — support remote agent file browsing
+- improve file path detection — support directory paths, code blocks, no-extension paths
+- add clickable file paths in chat — click path in message to open in workspace panel
+- unify AI and human bubble font size to 16px — consistent reading controls for both
+- fix AI bubble not responding to reading controls — remove inline font-size overrides
+- fix image preview URL — use query parameter for file path to avoid slash encoding issues
+- add image preview support in workspace panel — HTTP endpoint + centered display
+- remove sidebar collapsed persistence — always start with room list open on refresh
+- fix blank screen on refresh with collapsed sidebar — show rooms toggle on empty state
+- add proper markdown styling for workspace viewer — headings, lists, code blocks, tables
+- auto-request file tree on room join — workspace ready when panel opens
+- fix message actions position (above bubble), update bubble font sizes, add sidebar collapse button
+- wire workspace panel to backend — file:list, file:read, git:diff endpoints
+- implement full dev workspace panel — tab bar, file tree, code viewer, diff viewer, markdown, editing banner
+- add reading comfort controls — text size, line spacing, bubble width in Settings General
+- update syntax highlighting colors to Hearth design palette
+- add dev workspace panel shell — resizable split-pane with toggle button
+- add syntax highlighting for code blocks — highlight.js + custom warm theme

--- a/changelog/version-0-0-14.md
+++ b/changelog/version-0-0-14.md
@@ -1,0 +1,7 @@
+# v0.0.14 — 2026-05-30
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- cleanup: top-level require, pendingFileOps TTL, increase refresh debounce to 5s

--- a/changelog/version-0-0-15.md
+++ b/changelog/version-0-0-15.md
@@ -1,0 +1,7 @@
+# v0.0.15 — 2026-05-30
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- final audit fixes — schema index order, toast feedback on silent failures

--- a/changelog/version-0-0-16.md
+++ b/changelog/version-0-0-16.md
@@ -1,0 +1,7 @@
+# v0.0.16 — 2026-05-30
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- audit fix — avatar upload toast, document download file feature in EN+ID

--- a/docs/guide-usage.en.md
+++ b/docs/guide-usage.en.md
@@ -325,6 +325,44 @@ Stoa supports browser **push notifications** so you get alerted when agents resp
 
 ---
 
+## Workspace Panel
+
+The workspace panel is a code viewer and file browser that appears to the right of the chat. It lets you browse, read, and preview files on the AI agent's machine — including remote servers.
+
+### Opening the Panel
+
+Click the **panel toggle button** (split-pane icon) in the chat header. The panel opens to the right with a resizable drag handle.
+
+### File Tree (Files Tab)
+
+The **Files** tab shows the project directory tree for the room's working directory. Click any file to open it. Folders expand/collapse on click.
+
+### Code Viewer
+
+Text files open with **syntax highlighting** (powered by highlight.js), **line numbers**, and a dark code background. The breadcrumb at the top shows the file path.
+
+### Markdown Preview
+
+`.md` files render as formatted markdown with headings, lists, code blocks, tables, and links.
+
+### Image Preview
+
+Image files (PNG, JPG, GIF, WebP, SVG) display as a centered preview. For remote agents, images are fetched via the agent's WebSocket connection.
+
+### Git Diff (Git Tab)
+
+The **Git** tab shows uncommitted changes (`git diff`) with green/red line highlighting, file headers, and change statistics.
+
+### Clickable File Paths
+
+When an AI agent mentions a file path in a message (e.g., `/home/user/project/file.py`), the path becomes **clickable** — click it to open the file in the workspace panel. This works for paths inside backtick code blocks and code fences.
+
+### Remote File Browsing
+
+The workspace works with both local and remote agents. For remote agents, file operations are proxied through the agent's WebSocket connection — you can browse files on any machine the agent runs on, from any device (including tablets and phones).
+
+---
+
 ## Export Conversation
 
 You can export a room's full conversation history as **JSON** or **CSV**. Click the **export button** in the chat header and select the format. The download includes all messages, timestamps, and participant names.
@@ -356,6 +394,7 @@ Browse project documentation with multi-language support. Documentation files fr
 
 ### General
 
+- **Messages** — reading comfort controls: adjust text size (Compact / Cozy / Comfortable / Large), line spacing (Tight / Normal / Relaxed), and bubble width (Narrow / Standard / Wide). Changes apply to all rooms instantly with a live preview.
 - **Account** — change your email and password
 - **Notifications** — enable/disable browser push notifications
 - **Session** — log out of Stoa

--- a/docs/guide-usage.en.md
+++ b/docs/guide-usage.en.md
@@ -363,6 +363,10 @@ The **Git** tab shows uncommitted changes (`git diff`) with green/red line highl
 
 When an AI agent mentions a file path in a message (e.g., `/home/user/project/file.py`), the path becomes **clickable** — click it to open the file in the workspace panel. This works for paths inside backtick code blocks and code fences.
 
+### Download Files
+
+Hover over any file in the file tree to reveal a **download button** (arrow icon). Click it to download the file to your local device. This works for both local and remote agent files — remote files are fetched via WebSocket and delivered as a browser download.
+
 ### Remote File Browsing
 
 The workspace works with both local and remote agents. For remote agents, file operations are proxied through the agent's WebSocket connection — you can browse files on any machine the agent runs on, from any device (including tablets and phones).

--- a/docs/guide-usage.en.md
+++ b/docs/guide-usage.en.md
@@ -217,7 +217,7 @@ Press **Ctrl+F** (or click the **search icon** in the room header) to search wit
 
 ### Adding a New Agent
 
-Go to **Settings > Claude > Add Agent**. The Add Agent panel lets you configure:
+Go to **Settings > AI Agent > Add Agent**. The Add Agent panel lets you configure:
 
 - **Backend** — choose between **Claude Code CLI** or **Gemini CLI** as the AI backend. The install command adapts automatically based on your selection
 - **Language** — select the language the AI agent will use for responses: English, Bahasa Indonesia, 日本語, 한국語, or 中文
@@ -258,7 +258,7 @@ curl -fsSL http://YOUR_SERVER:3000/install.sh?name=Idris | bash
 
 ### Renaming an Agent
 
-Click the agent's name in **Settings > Claude** to edit it inline.
+Click the agent's name in **Settings > AI Agent** to edit it inline.
 
 ### Changing Agent Language
 
@@ -266,7 +266,7 @@ Each agent's response language can be changed after creation. Go to **Settings >
 
 ### Removing an Agent
 
-Click the **delete button** next to an agent in **Settings > Claude** to remove it. The agent is unregistered and removed from all rooms.
+Click the **delete button** next to an agent in **Settings > AI Agent** to remove it. The agent is unregistered and removed from all rooms.
 
 ### Agent Online Status
 
@@ -283,17 +283,17 @@ Agents automatically:
 
 Each agent has one or more **working directories** — these are the folders where the agent's Claude session runs. You can:
 
-- View an agent's workdirs in **Settings > Claude > [agent name]**
+- View an agent's workdirs in **Settings > AI Agent > [agent name]**
 - Add new workdirs via the UI or API
 - Assign a specific workdir to a room when creating it
 
 ### Client Versioning
 
-Each agent reports its **client version** (e.g., `v0.2.2`) to the server. You can see the version in **Settings > Claude** next to each agent's name. This helps track which agents are running the latest client code.
+Each agent reports its **client version** (e.g., `v0.2.2`) to the server. You can see the version in **Settings > AI Agent** next to each agent's name. This helps track which agents are running the latest client code.
 
 ### Agent Controls
 
-In **Settings > Claude**, each agent has two action buttons:
+In **Settings > AI Agent**, each agent has two action buttons:
 
 - **Rescan** — re-scan the agent's working directories and skills
 - **Force Update** — force the agent to check for client updates immediately (normally checks every 2 minutes)
@@ -322,6 +322,12 @@ AI agents can **suggest inviting** other agents into a room. When an agent think
 Stoa supports browser **push notifications** so you get alerted when agents respond, even when the tab is in the background.
 
 - Toggle notifications on/off in **Settings > General > Notifications**
+
+---
+
+## Sidebar Collapse
+
+Click the **double-chevron button** (‹‹) next to the Stoa logo to hide the room list sidebar, giving more space for the chat and workspace panel. To restore the sidebar, click the **panel icon** that appears in the chat header (or in the empty state).
 
 ---
 
@@ -373,7 +379,7 @@ You can export a room's full conversation history as **JSON** or **CSV**. Click 
 
 Click the **gear icon** in the sidebar to open the settings panel. Settings are organized into four tabs:
 
-### Claude (Agents)
+### AI Agent
 
 View all registered agents, their online status, version, workdirs, and skills. Add new agents, rename, remove, rescan, or force update.
 
@@ -385,6 +391,7 @@ View all registered agents, their online status, version, workdirs, and skills. 
 - **Port** — change the server port (requires restart; see the [port change guide](doc-port))
 - **Max AI Turns** — maximum agent responses per human message (prevents infinite loops)
 - **Concurrent Sessions** — how many messages an agent can process in parallel across all rooms (applied instantly, no restart needed)
+- **Session Idle TTL** — minutes before idle AI sessions auto-close to free memory (default 5 minutes)
 - **Cleanup Hour** — when the daily upload cleanup runs (24h format)
 - **Max File Age** — how long uploaded files are kept before cleanup (hours)
 

--- a/docs/guide-usage.id.md
+++ b/docs/guide-usage.id.md
@@ -363,6 +363,10 @@ Tab **Git** menampilkan perubahan yang belum di-commit (`git diff`) dengan highl
 
 Saat AI agent menyebut path file di pesan (misal `/home/user/project/file.py`), path tersebut menjadi **bisa diklik** — klik untuk membuka file di panel workspace. Ini berlaku untuk path di backtick dan code block.
 
+### Download File
+
+Hover di file mana saja di file tree untuk menampilkan **tombol download** (ikon panah). Klik untuk download file ke device lokal. Ini berlaku untuk file agent lokal maupun remote — file remote diambil via WebSocket dan dikirim sebagai download browser.
+
 ### Browsing File Remote
 
 Workspace bekerja dengan agent lokal maupun remote. Untuk agent remote, operasi file di-proxy melalui koneksi WebSocket agent — bisa browse file di mesin manapun agent berjalan, dari device apapun (termasuk tablet dan HP).

--- a/docs/guide-usage.id.md
+++ b/docs/guide-usage.id.md
@@ -325,6 +325,44 @@ Stoa mendukung **push notification** browser sehingga Anda mendapat notifikasi s
 
 ---
 
+## Panel Workspace
+
+Panel workspace adalah file browser dan code viewer yang muncul di sebelah kanan chat. Bisa digunakan untuk melihat file di mesin AI agent — termasuk server remote.
+
+### Membuka Panel
+
+Klik **tombol panel** (ikon split-pane) di header chat. Panel terbuka di kanan dengan drag handle untuk resize.
+
+### File Tree (Tab Files)
+
+Tab **Files** menampilkan directory tree dari working directory room. Klik file untuk membuka. Folder bisa expand/collapse.
+
+### Code Viewer
+
+File teks ditampilkan dengan **syntax highlighting** (highlight.js), **nomor baris**, dan background gelap. Breadcrumb di atas menunjukkan path file.
+
+### Markdown Preview
+
+File `.md` di-render sebagai markdown terformat — heading, list, code block, tabel, dan link.
+
+### Image Preview
+
+File gambar (PNG, JPG, GIF, WebP, SVG) ditampilkan sebagai preview terpusat. Untuk agent remote, gambar diambil via koneksi WebSocket agent.
+
+### Git Diff (Tab Git)
+
+Tab **Git** menampilkan perubahan yang belum di-commit (`git diff`) dengan highlight hijau/merah, header file, dan statistik perubahan.
+
+### Path File yang Bisa Diklik
+
+Saat AI agent menyebut path file di pesan (misal `/home/user/project/file.py`), path tersebut menjadi **bisa diklik** — klik untuk membuka file di panel workspace. Ini berlaku untuk path di backtick dan code block.
+
+### Browsing File Remote
+
+Workspace bekerja dengan agent lokal maupun remote. Untuk agent remote, operasi file di-proxy melalui koneksi WebSocket agent — bisa browse file di mesin manapun agent berjalan, dari device apapun (termasuk tablet dan HP).
+
+---
+
 ## Ekspor Percakapan
 
 Anda bisa mengekspor seluruh riwayat percakapan room sebagai **JSON** atau **CSV**. Klik **tombol export** di header chat dan pilih format. Download mencakup semua pesan, timestamp, dan nama peserta.
@@ -356,6 +394,7 @@ Jelajahi dokumentasi proyek dengan dukungan multi-bahasa. File dokumentasi dari 
 
 ### General
 
+- **Messages** — kontrol kenyamanan baca: atur ukuran teks (Compact / Cozy / Comfortable / Large), jarak baris (Tight / Normal / Relaxed), dan lebar bubble (Narrow / Standard / Wide). Perubahan langsung berlaku di semua room dengan preview langsung.
 - **Account** — ubah email dan password
 - **Notifications** — aktifkan/nonaktifkan push notification browser
 - **Session** — logout dari Stoa

--- a/docs/guide-usage.id.md
+++ b/docs/guide-usage.id.md
@@ -217,7 +217,7 @@ Tekan **Ctrl+F** (atau klik **ikon search** di header room) untuk mencari di dal
 
 ### Menambah Agent Baru
 
-Buka **Settings > Claude > Add Agent**. Panel Add Agent memungkinkan Anda mengonfigurasi:
+Buka **Settings > AI Agent > Add Agent**. Panel Add Agent memungkinkan Anda mengonfigurasi:
 
 - **Backend** — pilih antara **Claude Code CLI** atau **Gemini CLI** sebagai backend AI. Perintah install menyesuaikan secara otomatis berdasarkan pilihan Anda
 - **Bahasa** — pilih bahasa yang akan digunakan AI agent untuk merespons: English, Bahasa Indonesia, 日本語, 한국語, atau 中文
@@ -258,7 +258,7 @@ curl -fsSL http://SERVER_ANDA:3000/install.sh?name=Idris | bash
 
 ### Mengganti Nama Agent
 
-Klik nama agent di **Settings > Claude** untuk mengeditnya secara inline.
+Klik nama agent di **Settings > AI Agent** untuk mengeditnya secara inline.
 
 ### Mengubah Bahasa Agent
 
@@ -266,7 +266,7 @@ Bahasa respons setiap agent bisa diubah setelah pembuatan. Buka tab **Settings >
 
 ### Menghapus Agent
 
-Klik **tombol delete** di samping agent di **Settings > Claude** untuk menghapusnya. Agent akan di-unregister dan dihapus dari semua room.
+Klik **tombol delete** di samping agent di **Settings > AI Agent** untuk menghapusnya. Agent akan di-unregister dan dihapus dari semua room.
 
 ### Status Online Agent
 
@@ -283,17 +283,17 @@ Agent secara otomatis:
 
 Setiap agent memiliki satu atau lebih **working directory** — folder tempat sesi Claude agent berjalan. Anda bisa:
 
-- Melihat workdir agent di **Settings > Claude > [nama agent]**
+- Melihat workdir agent di **Settings > AI Agent > [nama agent]**
 - Menambah workdir baru via UI atau API
 - Menetapkan workdir tertentu ke room saat pembuatan
 
 ### Versi Klien
 
-Setiap agent melaporkan **versi klien** (misal `v0.2.2`) ke server. Versi bisa dilihat di **Settings > Claude** di samping nama agent. Ini membantu melacak agent mana yang menjalankan kode klien terbaru.
+Setiap agent melaporkan **versi klien** (misal `v0.2.2`) ke server. Versi bisa dilihat di **Settings > AI Agent** di samping nama agent. Ini membantu melacak agent mana yang menjalankan kode klien terbaru.
 
 ### Kontrol Agent
 
-Di **Settings > Claude**, setiap agent punya dua tombol aksi:
+Di **Settings > AI Agent**, setiap agent punya dua tombol aksi:
 
 - **Rescan** — scan ulang working directory dan skill agent
 - **Force Update** — paksa agent mengecek update klien segera (normalnya cek tiap 2 menit)
@@ -322,6 +322,12 @@ AI agent bisa **menyarankan mengundang** agent lain ke room. Saat agent merasa k
 Stoa mendukung **push notification** browser sehingga Anda mendapat notifikasi saat agent merespons, bahkan ketika tab di background.
 
 - Toggle notifikasi on/off di **Settings > General > Notifications**
+
+---
+
+## Collapse Sidebar
+
+Klik **tombol double-chevron** (‹‹) di samping logo Stoa untuk menyembunyikan sidebar room list, memberi lebih banyak ruang untuk chat dan panel workspace. Untuk mengembalikan sidebar, klik **ikon panel** yang muncul di header chat (atau di halaman kosong).
 
 ---
 
@@ -373,7 +379,7 @@ Anda bisa mengekspor seluruh riwayat percakapan room sebagai **JSON** atau **CSV
 
 Klik **ikon gear** di sidebar untuk membuka panel pengaturan. Pengaturan diorganisasi dalam empat tab:
 
-### Claude (Agent)
+### AI Agent
 
 Lihat semua agent yang terdaftar, status online, versi, workdir, dan skill mereka. Tambah agent baru, ganti nama, hapus, rescan, atau paksa update.
 
@@ -385,6 +391,7 @@ Lihat semua agent yang terdaftar, status online, versi, workdir, dan skill merek
 - **Port** — ubah port server (perlu restart; lihat [panduan ganti port](doc-port))
 - **Max AI Turns** — maksimum respons agent per pesan manusia (mencegah loop tak terbatas)
 - **Concurrent Sessions** — berapa pesan yang bisa diproses agent secara paralel di semua room (langsung diterapkan, tanpa restart)
+- **Session Idle TTL** — menit sebelum sesi AI yang idle otomatis ditutup untuk menghemat memori (default 5 menit)
 - **Cleanup Hour** — kapan pembersihan upload harian berjalan (format 24 jam)
 - **Max File Age** — berapa lama file upload disimpan sebelum dibersihkan (jam)
 

--- a/index.html
+++ b/index.html
@@ -4365,7 +4365,8 @@ async function restoreRoom(room) {
 async function deleteRoom(room) {
   if (!confirm(`Delete "${room.title}"? This cannot be undone.`)) return;
   try {
-    await fetch(`/api/rooms/${room.id}`, { method: 'DELETE' });
+    const res = await fetch(`/api/rooms/${room.id}`, { method: 'DELETE' });
+    if (!res.ok) throw new Error('delete failed');
   } catch { showToast('Failed to delete room', { error: true }); return; }
   if (currentRoomId === room.id) {
     currentRoomId = null;
@@ -5177,7 +5178,7 @@ function showCopyFeedback(btn) {
 }
 
 async function deleteMessage(msgId) {
-  try { await fetch(`/api/messages/${msgId}`, { method: 'DELETE' }); } catch { showToast('Failed to delete message', { error: true }); }
+  try { const res = await fetch(`/api/messages/${msgId}`, { method: 'DELETE' }); if (!res.ok) throw new Error(); } catch { showToast('Failed to delete message', { error: true }); }
 }
 
 function getAttachments(m) {

--- a/index.html
+++ b/index.html
@@ -4742,9 +4742,9 @@ function wsSetView(view) {
 function wsOpenFile(name, content) {
   const existing = wsOpenFiles.find(f => f.name === name);
   if (existing) {
-    if (content) existing.content = content;
+    if (content != null) { existing.content = content; existing.loaded = true; }
   } else {
-    wsOpenFiles.push({ name, content: content || '', ext: wsGetExt(name) });
+    wsOpenFiles.push({ name, content: content ?? '', ext: wsGetExt(name), loaded: content != null });
   }
   const imgExts = new Set(['png','jpg','jpeg','gif','webp','svg','ico','bmp']);
   const fileExt = wsGetExt(name);
@@ -4957,20 +4957,20 @@ function wsRenderContent() {
       return;
     }
 
-    if (ext === 'md' && file.content) {
+    if (ext === 'md' && file.loaded) {
       content.className = 'ws-scroll ws-md-view';
       content.style.cssText = 'flex:1;min-height:0;overflow:auto;padding:26px 30px 40px';
       const inner = document.createElement('div');
       inner.className = 'ws-md-body';
-      inner.innerHTML = DOMPurify.sanitize(marked.parse(file.content), { ADD_ATTR: ['class'] });
+      inner.innerHTML = file.content ? DOMPurify.sanitize(marked.parse(file.content), { ADD_ATTR: ['class'] }) : '<p style="color:var(--h-ink-faint);font-style:italic">empty file</p>';
       addCopyButtons(inner);
       content.appendChild(inner);
-    } else if (file.content) {
-      wsRenderCodeViewer(content, file.content);
+    } else if (file.loaded) {
+      wsRenderCodeViewer(content, file.content || '');
     } else {
       content.innerHTML = `<div class="ws-empty-state">
-        <div class="ws-empty-title">file viewer</div>
-        <div class="ws-empty-text">file content will load when the backend file:read API is connected.</div>
+        <div class="ws-empty-title">loading…</div>
+        <div class="ws-empty-text">fetching file from agent.</div>
       </div>`;
     }
   }

--- a/index.html
+++ b/index.html
@@ -893,7 +893,7 @@
     /* ── Markdown viewer ──────────────────────────── */
     .ws-md-body { max-width: 620px; }
     .ws-md-body h1 {
-      font-family: var(--h-serif); font-size: 28px; font-weight: 400;
+      font-family: var(--h-serif); font-size: 30px; font-weight: 400;
       color: var(--h-ink); margin: 0 0 12px; line-height: 1.15;
       padding-bottom: 10px; border-bottom: 1px solid var(--h-hair-soft);
     }

--- a/index.html
+++ b/index.html
@@ -890,6 +890,80 @@
     .ws-diff-line-del { background: color-mix(in srgb, oklch(0.58 0.12 28) 16%, oklch(0.193 0.016 44)); }
     .ws-diff-line-empty { background: rgba(0,0,0,.18); }
 
+    /* ── Markdown viewer ──────────────────────────── */
+    .ws-md-body { max-width: 620px; }
+    .ws-md-body h1 {
+      font-family: var(--h-serif); font-size: 28px; font-weight: 400;
+      color: var(--h-ink); margin: 0 0 12px; line-height: 1.15;
+      padding-bottom: 10px; border-bottom: 1px solid var(--h-hair-soft);
+    }
+    .ws-md-body h2 {
+      font-family: var(--h-serif); font-size: 21px; font-weight: 400;
+      color: var(--h-ink); margin: 28px 0 10px; line-height: 1.2;
+    }
+    .ws-md-body h3 {
+      font-family: var(--h-serif); font-size: 17px; font-weight: 500;
+      color: var(--h-ink); margin: 22px 0 8px;
+    }
+    .ws-md-body h4, .ws-md-body h5, .ws-md-body h6 {
+      font-family: var(--h-serif); font-size: 15px; font-weight: 500;
+      color: var(--h-ink-mute); margin: 18px 0 6px;
+    }
+    .ws-md-body p {
+      font-family: var(--h-sans); font-size: 15px; line-height: 1.65;
+      color: var(--h-ink); margin: 0 0 16px; text-wrap: pretty;
+    }
+    .ws-md-body ul, .ws-md-body ol {
+      font-family: var(--h-sans); font-size: 15px; line-height: 1.65;
+      color: var(--h-ink); padding-left: 22px; margin: 0 0 16px;
+    }
+    .ws-md-body li { margin-bottom: 4px; }
+    .ws-md-body li > ul, .ws-md-body li > ol { margin: 4px 0 0; }
+    .ws-md-body blockquote {
+      border-left: 3px solid var(--h-hairline); margin: 0 0 16px;
+      padding: 2px 0 2px 16px; color: var(--h-ink-mute);
+    }
+    .ws-md-body hr {
+      border: none; border-top: 1px solid var(--h-hair-soft); margin: 24px 0;
+    }
+    .ws-md-body a {
+      color: var(--h-accent); text-decoration: underline;
+      text-underline-offset: 3px;
+    }
+    .ws-md-body a:hover { color: var(--h-ink); }
+    .ws-md-body strong { color: var(--h-ink); font-weight: 600; }
+    .ws-md-body em { font-style: italic; }
+    .ws-md-body :not(pre) > code {
+      font-family: "Cascadia Code", "Fira Code", Consolas, monospace;
+      font-size: 0.85em; padding: 1px 6px; border-radius: 5px;
+      background: color-mix(in srgb, var(--h-ink) 9%, var(--h-surface));
+      color: var(--h-ink-mute);
+    }
+    .ws-md-body pre {
+      position: relative; margin: 0 0 16px; border-radius: 8px;
+      background: oklch(0.193 0.016 44); overflow-x: auto;
+    }
+    .ws-md-body pre code {
+      display: block; padding: 14px 16px; padding-right: 52px;
+      font-family: "Cascadia Code", "Fira Code", Consolas, monospace;
+      font-size: 13px; line-height: 1.6; color: #d3c8b4;
+      white-space: pre-wrap; overflow-wrap: break-word;
+      background: transparent;
+    }
+    .ws-md-body table {
+      border-collapse: collapse; margin: 0 0 16px;
+      font-family: var(--h-sans); font-size: 14px; width: auto;
+    }
+    .ws-md-body th, .ws-md-body td {
+      border: 1px solid var(--h-hair-soft); padding: 6px 12px; text-align: left;
+    }
+    .ws-md-body th {
+      background: color-mix(in srgb, var(--h-hairline) 30%, transparent);
+      font-weight: 600; color: var(--h-ink);
+    }
+    .ws-md-body td { color: var(--h-ink-mute); }
+    .ws-md-body img { max-width: 100%; border-radius: 8px; margin: 8px 0; }
+
     /* ── Editing banner ───────────────────────────── */
     .ws-editing-banner {
       display: flex;
@@ -4811,11 +4885,12 @@ function wsRenderContent() {
     wsSetToolbar(parts);
 
     if (ext === 'md' && file.content) {
-      content.className = 'ws-scroll';
+      content.className = 'ws-scroll ws-md-view';
       content.style.cssText = 'flex:1;min-height:0;overflow:auto;padding:26px 30px 40px';
       const inner = document.createElement('div');
-      inner.style.maxWidth = '620px';
+      inner.className = 'ws-md-body';
       inner.innerHTML = DOMPurify.sanitize(marked.parse(file.content), { ADD_ATTR: ['class'] });
+      addCopyButtons(inner);
       content.appendChild(inner);
     } else if (file.content) {
       wsRenderCodeViewer(content, file.content);

--- a/index.html
+++ b/index.html
@@ -6176,15 +6176,16 @@ async function submitNewRoom() {
   if (!workdir_id) { alert('Please select a working directory'); return; }
   document.getElementById('new-room-modal').style.display = 'none';
 
-  const room = await fjson('/api/rooms', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ title, participant_ids, workdir_id }),
-  });
-
-  const rooms = await fjson('/api/rooms');
-  renderRoomList(rooms);
-  openRoom(room);
+  try {
+    const room = await fjson('/api/rooms', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, participant_ids, workdir_id }),
+    });
+    const rooms = await fjson('/api/rooms');
+    renderRoomList(rooms);
+    openRoom(room);
+  } catch { showToast('Failed to create room', { error: true }); }
 }
 
 // ── Scroll ──────────────────────────────────────────────────────────────────
@@ -6368,7 +6369,12 @@ async function doRoomSearch(query) {
     countEl.textContent = '';
     return;
   }
-  const rows = await fetch(`/api/search?q=${encodeURIComponent(query)}&room_id=${currentRoomId}&limit=50`).then(r => r.json());
+  let rows;
+  try {
+    const res = await fetch(`/api/search?q=${encodeURIComponent(query)}&room_id=${currentRoomId}&limit=50`);
+    if (!res.ok) throw new Error();
+    rows = await res.json();
+  } catch { countEl.textContent = 'search failed'; return; }
   countEl.textContent = rows.length ? `${rows.length} found` : 'no results';
   if (!rows.length) { resultsEl.classList.remove('visible'); return; }
   resultsEl.classList.add('visible');

--- a/index.html
+++ b/index.html
@@ -8468,9 +8468,9 @@ async function sResizeAndUploadAvatar(file) {
           renderSidebarFooter();
           renderComposerSeal();
         }
-      } catch (err) { console.error('avatar upload failed', err); }
+      } catch (err) { console.error('avatar upload failed', err); showToast('Failed to upload avatar', { error: true }); }
     };
-    img.onerror = () => console.error('Failed to load image for avatar');
+    img.onerror = () => { console.error('Failed to load image for avatar'); showToast('Invalid image file', { error: true }); };
     img.src = origDataUrl;
   };
   reader.onerror = () => console.error('Failed to read file for avatar');

--- a/index.html
+++ b/index.html
@@ -4894,7 +4894,7 @@ function wsRenderContent() {
       content.className = 'ws-scroll';
       content.style.cssText = 'flex:1;min-height:0;overflow:auto;display:flex;align-items:center;justify-content:center;padding:24px;background:color-mix(in srgb,var(--h-ink) 4%,var(--h-bg))';
       const img = document.createElement('img');
-      img.src = `/api/workspace/file/${encodeURIComponent(file.name)}?room=${currentRoomId}`;
+      img.src = `/api/workspace/file?room=${currentRoomId}&path=${encodeURIComponent(file.name)}`;
       img.style.cssText = 'max-width:100%;max-height:100%;object-fit:contain;border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,.12)';
       img.alt = file.name;
       content.appendChild(img);

--- a/index.html
+++ b/index.html
@@ -4829,7 +4829,7 @@ function wsScheduleRefresh() {
       ws.send(JSON.stringify({ type: 'git_diff' }));
     }
     wsRefreshTimer = null;
-  }, 3000);
+  }, 5000);
 }
 
 function toggleWorkspacePanel() {

--- a/index.html
+++ b/index.html
@@ -5189,15 +5189,17 @@ function wsShowEditingBanner(actorName, actorColor) {
 marked.use({
   breaks: true, gfm: true,
   renderer: {
-    code({ text, lang, raw }) {
-      const src = text || raw?.replace(/^```\w*\n?|\n?```$/g, '') || '';
+    code(token) {
+      const src = (typeof token === 'string' ? token : token.text) ?? '';
+      const lang = typeof token === 'string' ? '' : (token.lang || '');
+      if (!src) return `<pre><code>${''}</code></pre>`;
       let highlighted;
       const language = lang && hljs.getLanguage(lang) ? lang : null;
       try {
         highlighted = language
           ? hljs.highlight(src, { language }).value
           : hljs.highlightAuto(src).value;
-      } catch { highlighted = src; }
+      } catch { highlighted = src.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
       const langLabel = language
         ? `<span class="h-code-lang">${language}</span>`
         : '';

--- a/index.html
+++ b/index.html
@@ -495,9 +495,133 @@
     #main {
       flex: 1;
       display: flex;
+      flex-direction: row;
+      min-width: 0;
+      overflow: hidden;
+    }
+
+    #chat-area {
+      flex: 1;
+      display: flex;
       flex-direction: column;
       min-width: 0;
       overflow: hidden;
+    }
+
+    /* ── Dev workspace panel ─────────────────────────────── */
+    #workspace-panel {
+      display: none;
+      flex-direction: column;
+      width: var(--ws-panel-width, 40%);
+      min-width: 280px;
+      max-width: 70%;
+      background: var(--h-bg);
+      border-left: 1px solid var(--h-hairline);
+      overflow: hidden;
+    }
+    #workspace-panel.open { display: flex; }
+
+    #ws-drag-handle {
+      position: absolute;
+      left: -3px;
+      top: 0;
+      bottom: 0;
+      width: 6px;
+      cursor: col-resize;
+      z-index: 10;
+      background: transparent;
+      transition: background 0.15s;
+    }
+    #ws-drag-handle:hover, #ws-drag-handle.dragging {
+      background: var(--h-accent);
+      opacity: 0.4;
+    }
+    #ws-drag-handle.dragging { opacity: 0.6; }
+
+    #ws-panel-header {
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--h-hair-soft);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      background: var(--h-header-bg);
+      flex: 0 0 auto;
+    }
+
+    #ws-panel-title {
+      font-family: var(--h-serif);
+      font-size: 14px;
+      color: var(--h-ink);
+    }
+
+    .ws-panel-close {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--h-ink-faint);
+      padding: 4px;
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: color 0.12s, background 0.12s;
+    }
+    .ws-panel-close:hover { color: var(--h-ink); background: var(--h-surface); }
+
+    #ws-panel-content {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: auto;
+    }
+
+    .ws-empty-state {
+      text-align: center;
+      padding: 40px 24px;
+    }
+    .ws-empty-icon { color: var(--h-ink-faint); opacity: 0.4; margin-bottom: 16px; }
+    .ws-empty-text {
+      font-family: var(--h-serif);
+      font-style: italic;
+      font-size: 14px;
+      color: var(--h-ink-faint);
+      line-height: 1.5;
+      max-width: 240px;
+    }
+
+    .h-ws-toggle {
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: var(--h-ink-faint);
+      padding: 4px;
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: color 0.12s, background 0.12s;
+      margin-left: 8px;
+    }
+    .h-ws-toggle:hover { color: var(--h-ink); background: var(--h-surface-hi); }
+    .h-ws-toggle.active { color: var(--h-accent); }
+
+    @media (max-width: 1200px) {
+      #workspace-panel.open {
+        position: absolute;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        z-index: 50;
+        box-shadow: -4px 0 24px rgba(0,0,0,0.15);
+      }
+    }
+    @media (max-width: 680px) {
+      #workspace-panel.open {
+        width: 100% !important;
+        min-width: 0;
+        max-width: 100%;
+      }
     }
 
     /* Empty state */
@@ -2662,6 +2786,7 @@
 </aside>
 
 <main id="main">
+<div id="chat-area">
   <div id="empty-state">
     <div class="h-faded-mark" aria-hidden="true">
       <svg width="165" height="127" viewBox="0 0 260 200">
@@ -2974,6 +3099,29 @@
       </div>
     </div>
   </div>
+</div><!-- /chat-area -->
+
+<div id="workspace-panel" style="position:relative">
+  <div id="ws-drag-handle"></div>
+  <div id="ws-panel-header">
+    <span id="ws-panel-title">workspace</span>
+    <button class="ws-panel-close" id="ws-panel-close-btn" title="Close panel">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+    </button>
+  </div>
+  <div id="ws-panel-content">
+    <div class="ws-empty-state">
+      <div class="ws-empty-icon">
+        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
+          <polyline points="13 2 13 9 20 9"/>
+        </svg>
+      </div>
+      <div class="ws-empty-text">open a file or click a file reference in chat.</div>
+    </div>
+  </div>
+</div><!-- /workspace-panel -->
+
 </main>
 
 <!-- New-room modal -->
@@ -3451,6 +3599,13 @@ function renderChatHeader(room, participants) {
   exportWrap.appendChild(exportBtn);
   exportWrap.appendChild(exportDrop);
   header.appendChild(exportWrap);
+
+  const wsToggle = document.createElement('button');
+  wsToggle.className = 'h-ws-toggle h-header-action-btn' + (document.getElementById('workspace-panel').classList.contains('open') ? ' active' : '');
+  wsToggle.title = 'Dev Workspace';
+  wsToggle.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="12" y1="3" x2="12" y2="21"/><line x1="12" y1="9" x2="21" y2="9"/></svg>`;
+  wsToggle.onclick = toggleWorkspacePanel;
+  header.appendChild(wsToggle);
 }
 
 // ── Composer seal ──────────────────────────────────────────────────────────
@@ -3973,6 +4128,85 @@ function applyTheme(dark) {
 function toggleTheme() {
   applyTheme(!document.documentElement.classList.contains('dark'));
 }
+
+// ── Workspace panel ───────────────────────────────────────────────────────
+function toggleWorkspacePanel() {
+  const panel = document.getElementById('workspace-panel');
+  const isOpen = panel.classList.toggle('open');
+  document.querySelectorAll('.h-ws-toggle').forEach(b => b.classList.toggle('active', isOpen));
+  if (isOpen) {
+    const saved = localStorage.getItem('stoa-ws-panel-width');
+    if (saved) panel.style.setProperty('--ws-panel-width', saved);
+  }
+}
+
+(function initWorkspacePanel() {
+  const panel = document.getElementById('workspace-panel');
+  const handle = document.getElementById('ws-drag-handle');
+  const closeBtn = document.getElementById('ws-panel-close-btn');
+
+  closeBtn.onclick = toggleWorkspacePanel;
+
+  let dragging = false;
+  let startX = 0;
+  let startWidth = 0;
+
+  handle.addEventListener('mousedown', e => {
+    e.preventDefault();
+    dragging = true;
+    startX = e.clientX;
+    startWidth = panel.offsetWidth;
+    handle.classList.add('dragging');
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  });
+
+  document.addEventListener('mousemove', e => {
+    if (!dragging) return;
+    const diff = startX - e.clientX;
+    const newWidth = Math.max(280, Math.min(startWidth + diff, window.innerWidth * 0.7));
+    panel.style.setProperty('--ws-panel-width', newWidth + 'px');
+  });
+
+  document.addEventListener('mouseup', () => {
+    if (!dragging) return;
+    dragging = false;
+    handle.classList.remove('dragging');
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+    const w = panel.style.getPropertyValue('--ws-panel-width');
+    if (w) localStorage.setItem('stoa-ws-panel-width', w);
+  });
+
+  handle.addEventListener('dblclick', () => {
+    panel.style.removeProperty('--ws-panel-width');
+    localStorage.removeItem('stoa-ws-panel-width');
+  });
+
+  handle.addEventListener('touchstart', e => {
+    const touch = e.touches[0];
+    dragging = true;
+    startX = touch.clientX;
+    startWidth = panel.offsetWidth;
+    handle.classList.add('dragging');
+  }, { passive: true });
+
+  document.addEventListener('touchmove', e => {
+    if (!dragging) return;
+    const touch = e.touches[0];
+    const diff = startX - touch.clientX;
+    const newWidth = Math.max(280, Math.min(startWidth + diff, window.innerWidth * 0.7));
+    panel.style.setProperty('--ws-panel-width', newWidth + 'px');
+  }, { passive: true });
+
+  document.addEventListener('touchend', () => {
+    if (!dragging) return;
+    dragging = false;
+    handle.classList.remove('dragging');
+    const w = panel.style.getPropertyValue('--ws-panel-width');
+    if (w) localStorage.setItem('stoa-ws-panel-width', w);
+  });
+})();
 
 // ── Markdown rendering ─────────────────────────────────────────────────────
 marked.use({

--- a/index.html
+++ b/index.html
@@ -5189,14 +5189,15 @@ function wsShowEditingBanner(actorName, actorColor) {
 marked.use({
   breaks: true, gfm: true,
   renderer: {
-    code({ text, lang }) {
+    code({ text, lang, raw }) {
+      const src = text || raw?.replace(/^```\w*\n?|\n?```$/g, '') || '';
       let highlighted;
       const language = lang && hljs.getLanguage(lang) ? lang : null;
       try {
         highlighted = language
-          ? hljs.highlight(text, { language }).value
-          : hljs.highlightAuto(text).value;
-      } catch { highlighted = text; }
+          ? hljs.highlight(src, { language }).value
+          : hljs.highlightAuto(src).value;
+      } catch { highlighted = src; }
       const langLabel = language
         ? `<span class="h-code-lang">${language}</span>`
         : '';

--- a/index.html
+++ b/index.html
@@ -632,6 +632,23 @@
     }
     .ws-pin-tab.active .ws-tab-indicator { display: block; }
 
+    .ws-git-badge {
+      position: absolute;
+      top: 5px; right: 4px;
+      min-width: 14px; height: 14px;
+      border-radius: 7px;
+      background: #d39749;
+      color: #fff;
+      font-family: var(--h-sans);
+      font-size: 9px;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 3px;
+      line-height: 1;
+    }
+
     .ws-tab-divider { width: 1px; background: var(--h-hair-soft); margin: 8px 4px; }
 
     .ws-tab-list {
@@ -4447,6 +4464,7 @@ function connectWS(roomId) {
   ws.onopen = () => {
     ws.send(JSON.stringify({ type: 'join_room', room_id: roomId }));
     ws.send(JSON.stringify({ type: 'file_list' }));
+    ws.send(JSON.stringify({ type: 'git_diff' }));
     setConnected(true);
   };
 
@@ -4637,8 +4655,17 @@ function handleWsMessage(msg) {
     return;
   }
 
-  if (msg.type === 'git_diff' && !msg.error) {
+  if (msg.type === 'git_diff') {
+    if (msg.error) { console.warn('[ws] git_diff error:', msg.error); return; }
     wsGitDiffData = msg.files || [];
+    const gitTab = document.querySelector('[data-ws-pin="git"]');
+    if (gitTab) {
+      let badge = gitTab.querySelector('.ws-git-badge');
+      if (wsGitDiffData.length) {
+        if (!badge) { badge = document.createElement('span'); badge.className = 'ws-git-badge'; gitTab.appendChild(badge); }
+        badge.textContent = wsGitDiffData.length;
+      } else if (badge) { badge.remove(); }
+    }
     if (wsActiveView === 'git') wsRenderContent();
     return;
   }

--- a/index.html
+++ b/index.html
@@ -4442,6 +4442,26 @@ function handleWsMessage(msg) {
     handleServerRestart(msg);
     return;
   }
+
+  if (msg.type === 'file_list' && !msg.error) {
+    wsFileTreeData = msg.tree || [];
+    wsFileTreeRoot = msg.root || '';
+    if (wsActiveView === 'files') wsRenderContent();
+    return;
+  }
+
+  if (msg.type === 'file_read' && !msg.error) {
+    const panel = document.getElementById('workspace-panel');
+    if (!panel.classList.contains('open')) toggleWorkspacePanel();
+    wsOpenFile(msg.path, msg.content);
+    return;
+  }
+
+  if (msg.type === 'git_diff' && !msg.error) {
+    wsGitDiffData = msg.files || [];
+    if (wsActiveView === 'git') wsRenderContent();
+    return;
+  }
 }
 
 // ── Server restart notification ───────────────────────────────────────────
@@ -4505,6 +4525,9 @@ function wsGetExt(name) { return (name.match(/\.(\w+)$/) || [])[1] || ''; }
 let wsActiveView = 'files';
 let wsOpenFiles = [];
 let wsActiveFile = null;
+let wsFileTreeData = [];
+let wsFileTreeRoot = '';
+let wsGitDiffData = [];
 
 function toggleWorkspacePanel() {
   const panel = document.getElementById('workspace-panel');
@@ -4513,26 +4536,92 @@ function toggleWorkspacePanel() {
   if (isOpen) {
     const saved = localStorage.getItem('stoa-ws-panel-width');
     if (saved) panel.style.setProperty('--ws-panel-width', saved);
+    if (ws && wsActiveView === 'files') ws.send(JSON.stringify({ type: 'file_list' }));
+    if (ws && wsActiveView === 'git') ws.send(JSON.stringify({ type: 'git_diff' }));
   }
 }
 
 function wsSetView(view) {
   wsActiveView = view;
+  wsActiveFile = null;
   document.querySelectorAll('.ws-pin-tab').forEach(t => {
     t.classList.toggle('active', t.dataset.wsPin === view);
   });
+  if (view === 'files' && ws) ws.send(JSON.stringify({ type: 'file_list' }));
+  if (view === 'git' && ws) ws.send(JSON.stringify({ type: 'git_diff' }));
   wsRenderContent();
 }
 
 function wsOpenFile(name, content) {
-  if (!wsOpenFiles.find(f => f.name === name)) {
+  const existing = wsOpenFiles.find(f => f.name === name);
+  if (existing) {
+    if (content) existing.content = content;
+  } else {
     wsOpenFiles.push({ name, content: content || '', ext: wsGetExt(name) });
+  }
+  if (!content && ws) {
+    ws.send(JSON.stringify({ type: 'file_read', path: name }));
   }
   wsActiveFile = name;
   wsActiveView = 'file';
   document.querySelectorAll('.ws-pin-tab').forEach(t => t.classList.remove('active'));
   wsRenderTabs();
   wsRenderContent();
+}
+
+function wsRenderFileTree(container, nodes, parentPath) {
+  nodes.forEach(node => {
+    const row = document.createElement('div');
+    row.className = 'ws-tree-row';
+    row.style.paddingLeft = (8 + node.depth * 16) + 'px';
+
+    if (node.t === 'folder') {
+      const chevron = document.createElement('span');
+      chevron.className = 'ws-tree-chevron' + (node.open ? ' open' : '');
+      chevron.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M9 6l6 6-6 6"/></svg>';
+      row.appendChild(chevron);
+      const folderIcon = document.createElement('span');
+      folderIcon.style.cssText = 'color:var(--h-ink-mute);display:inline-flex';
+      folderIcon.innerHTML = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2.5h8a2 2 0 0 1 2 2V18a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>';
+      row.appendChild(folderIcon);
+      const nameEl = document.createElement('span');
+      nameEl.className = 'ws-tree-name folder';
+      nameEl.textContent = node.name;
+      row.appendChild(nameEl);
+
+      const childContainer = document.createElement('div');
+      childContainer.style.display = node.open ? '' : 'none';
+
+      row.onclick = () => {
+        node.open = !node.open;
+        chevron.classList.toggle('open', node.open);
+        childContainer.style.display = node.open ? '' : 'none';
+      };
+
+      container.appendChild(row);
+      if (node.children) {
+        wsRenderFileTree(childContainer, node.children, parentPath ? parentPath + '/' + node.name : node.name);
+      }
+      container.appendChild(childContainer);
+    } else {
+      const spacer = document.createElement('span');
+      spacer.style.cssText = 'width:12px;flex:0 0 auto';
+      row.appendChild(spacer);
+      row.appendChild(wsFileGlyph(node.t, 14));
+      const nameEl = document.createElement('span');
+      nameEl.className = 'ws-tree-name file';
+      nameEl.textContent = node.name;
+      row.appendChild(nameEl);
+
+      const filePath = parentPath ? parentPath + '/' + node.name : node.name;
+      row.onclick = () => {
+        const panel = document.getElementById('workspace-panel');
+        if (!panel.classList.contains('open')) toggleWorkspacePanel();
+        wsOpenFile(filePath);
+      };
+      container.appendChild(row);
+    }
+  });
 }
 
 function wsCloseFile(name) {
@@ -4601,21 +4690,50 @@ function wsRenderContent() {
 
   if (wsActiveView === 'files') {
     wsSetToolbar(null);
-    content.innerHTML = `<div class="ws-empty-state">
-      <span class="ws-empty-icon"><svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h7M4 12h10M4 18h6"/><circle cx="18" cy="6" r="1.4" fill="currentColor" stroke="none"/></svg></span>
-      <div class="ws-empty-title">nothing open yet</div>
-      <div class="ws-empty-text">open a file, or click a file reference in the chat to read it here.</div>
-    </div>`;
+    if (wsFileTreeData.length) {
+      content.className = 'ws-tree ws-scroll';
+      content.style.cssText = '';
+      wsRenderFileTree(content, wsFileTreeData, '');
+    } else {
+      content.innerHTML = `<div class="ws-empty-state">
+        <span class="ws-empty-icon"><svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h7M4 12h10M4 18h6"/><circle cx="18" cy="6" r="1.4" fill="currentColor" stroke="none"/></svg></span>
+        <div class="ws-empty-title">nothing open yet</div>
+        <div class="ws-empty-text">open a file, or click a file reference in the chat to read it here.</div>
+      </div>`;
+    }
     return;
   }
 
   if (wsActiveView === 'git') {
-    wsSetToolbar(['working tree']);
-    content.innerHTML = `<div class="ws-empty-state">
-      <span class="ws-empty-icon"><svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="6.5" cy="6" r="2.2"/><circle cx="6.5" cy="18" r="2.2"/><circle cx="17.5" cy="8" r="2.2"/><path d="M6.5 8.2v7.6M8.7 8c4 .2 6.5 1 8.6 .2M17.5 10.2c0 3.2-3 4.6-6.2 4.8"/></svg></span>
-      <div class="ws-empty-title">no changes</div>
-      <div class="ws-empty-text">git diff data will appear here when the backend is connected.</div>
-    </div>`;
+    if (wsGitDiffData.length) {
+      wsSetToolbar(['working tree', wsGitDiffData.length + ' file' + (wsGitDiffData.length > 1 ? 's' : '') + ' changed']);
+      wsGitDiffData.forEach(file => {
+        const hdr = document.createElement('div');
+        hdr.className = 'ws-diff-file-header';
+        hdr.appendChild(wsFileGlyph(wsGetExt(file.name), 14));
+        const fname = document.createElement('span');
+        fname.className = 'ws-mono';
+        fname.style.cssText = 'font-size:12.5px;color:var(--h-ink)';
+        fname.textContent = file.name;
+        hdr.appendChild(fname);
+        hdr.appendChild(document.createElement('span')).style.flex = '1';
+        const stat = document.createElement('span');
+        stat.className = 'ws-diff-stat';
+        stat.innerHTML = `<span class="ws-diff-add">+${file.add}</span><span class="ws-diff-del">−${file.del}</span>`;
+        hdr.appendChild(stat);
+        content.appendChild(hdr);
+        const diffContainer = document.createElement('div');
+        wsRenderDiff(diffContainer, file.hunks, 'unified');
+        content.appendChild(diffContainer);
+      });
+    } else {
+      wsSetToolbar(['working tree']);
+      content.innerHTML = `<div class="ws-empty-state">
+        <span class="ws-empty-icon"><svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="6.5" cy="6" r="2.2"/><circle cx="6.5" cy="18" r="2.2"/><circle cx="17.5" cy="8" r="2.2"/><path d="M6.5 8.2v7.6M8.7 8c4 .2 6.5 1 8.6 .2M17.5 10.2c0 3.2-3 4.6-6.2 4.8"/></svg></span>
+        <div class="ws-empty-title">no changes</div>
+        <div class="ws-empty-text">working tree is clean.</div>
+      </div>`;
+    }
     return;
   }
 

--- a/index.html
+++ b/index.html
@@ -852,6 +852,24 @@
       border-radius: 50%;
       flex: 0 0 auto;
     }
+    .ws-dl {
+      opacity: 0;
+      flex: 0 0 auto;
+      width: 22px;
+      height: 22px;
+      padding: 0;
+      border-radius: 5px;
+      border: none;
+      cursor: pointer;
+      background: transparent;
+      color: var(--h-ink-mute);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: opacity .12s, background .12s, color .12s;
+    }
+    .ws-tree-row:hover .ws-dl { opacity: .55; }
+    .ws-dl:hover { background: var(--h-surface); color: var(--h-ink) !important; opacity: 1 !important; }
 
     /* ── Code viewer ──────────────────────────────── */
     .ws-code-viewer {
@@ -4752,6 +4770,56 @@ let wsFileTreeRoot = '';
 let wsGitDiffData = [];
 let wsModifiedFiles = new Set();
 
+function wsDownloadFile(relPath, fileName) {
+  const fullPath = wsFileTreeRoot ? wsFileTreeRoot.replace(/\\/g, '/').replace(/\/+$/, '') + '/' + relPath : relPath;
+  const isAbs = /^\//.test(fullPath) || /^[A-Za-z]:/.test(fullPath);
+  const imgExts = new Set(['png','jpg','jpeg','gif','webp','svg','ico','bmp']);
+  const ext = wsGetExt(fileName);
+  const binary = imgExts.has(ext);
+
+  const existing = wsOpenFiles.find(f => f.name === fullPath);
+  if (existing && (existing.content || existing.base64)) {
+    triggerDownload(fileName, existing.content, existing.base64, ext);
+    return;
+  }
+
+  const handler = (e) => {
+    let msg; try { msg = JSON.parse(e.data); } catch { return; }
+    if (msg.type !== 'file_read' || (msg.path !== fullPath && msg.path !== relPath)) return;
+    ws.removeEventListener('message', handler);
+    if (msg.error) { showToast('Download failed: ' + msg.error, { error: true }); return; }
+    triggerDownload(fileName, msg.content, msg.base64, ext);
+  };
+  ws.addEventListener('message', handler);
+  setTimeout(() => ws.removeEventListener('message', handler), 15000);
+
+  const req = { type: 'file_read', path: fullPath };
+  if (binary) req.binary = true;
+  if (isAbs) req.absolute = true;
+  ws.send(JSON.stringify(req));
+}
+
+function triggerDownload(name, content, base64, ext) {
+  let blob;
+  if (base64) {
+    const mimeMap = { png:'image/png', jpg:'image/jpeg', jpeg:'image/jpeg', gif:'image/gif', webp:'image/webp', svg:'image/svg+xml', ico:'image/x-icon', bmp:'image/bmp', pdf:'application/pdf' };
+    const bin = atob(base64);
+    const arr = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+    blob = new Blob([arr], { type: mimeMap[ext] || 'application/octet-stream' });
+  } else {
+    blob = new Blob([content || ''], { type: 'text/plain;charset=utf-8' });
+  }
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = name;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
 let wsRefreshTimer = null;
 function wsScheduleRefresh() {
   if (wsRefreshTimer) clearTimeout(wsRefreshTimer);
@@ -4855,6 +4923,12 @@ function wsRenderFileTree(container, nodes, parentPath) {
       row.appendChild(nameEl);
 
       const relPath = parentPath ? parentPath + '/' + node.name : node.name;
+      const dlBtn = document.createElement('button');
+      dlBtn.className = 'ws-dl';
+      dlBtn.title = 'Download ' + node.name;
+      dlBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4v10"/><path d="M8 11l4 4 4-4"/><path d="M5 19h14"/></svg>';
+      dlBtn.onclick = (e) => { e.stopPropagation(); wsDownloadFile(relPath, node.name); };
+      row.appendChild(dlBtn);
       if (wsModifiedFiles.has(relPath) || wsModifiedFiles.has(node.name)) {
         const dot = document.createElement('span');
         dot.className = 'ws-tree-modified';

--- a/index.html
+++ b/index.html
@@ -4550,7 +4550,10 @@ function handleWsMessage(msg) {
     finalizeMessage(msg.message_id, msg.content, msg.file_url, msg.file_name, msg.attachments);
     clearComposerProcessing(msg.message_id);
     refreshRoomList();
-    // Desktop notification for agent messages in current room (when not focused)
+    if (ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: 'file_list' }));
+      ws.send(JSON.stringify({ type: 'git_diff' }));
+    }
     if (document.visibilityState !== 'visible') {
       const el = document.getElementById('msg-' + msg.message_id);
       const actorName = el?.querySelector('.h-msg-name')?.textContent || 'Agent';
@@ -4561,6 +4564,7 @@ function handleWsMessage(msg) {
 
   if (msg.type === 'message_tool') {
     appendToolStep(msg.message_id, msg.tool);
+    wsScheduleRefresh();
     return;
   }
 
@@ -4747,6 +4751,18 @@ let wsFileTreeData = [];
 let wsFileTreeRoot = '';
 let wsGitDiffData = [];
 let wsModifiedFiles = new Set();
+
+let wsRefreshTimer = null;
+function wsScheduleRefresh() {
+  if (wsRefreshTimer) clearTimeout(wsRefreshTimer);
+  wsRefreshTimer = setTimeout(() => {
+    if (ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: 'file_list' }));
+      ws.send(JSON.stringify({ type: 'git_diff' }));
+    }
+    wsRefreshTimer = null;
+  }, 3000);
+}
 
 function toggleWorkspacePanel() {
   const panel = document.getElementById('workspace-panel');

--- a/index.html
+++ b/index.html
@@ -4703,7 +4703,8 @@ function wsOpenFile(name, content) {
   } else {
     wsOpenFiles.push({ name, content: content || '', ext: wsGetExt(name) });
   }
-  if (!content && ws) {
+  const imgExts = new Set(['png','jpg','jpeg','gif','webp','svg','ico','bmp']);
+  if (!content && !imgExts.has(wsGetExt(name)) && ws) {
     ws.send(JSON.stringify({ type: 'file_read', path: name }));
   }
   wsActiveFile = name;
@@ -4887,6 +4888,18 @@ function wsRenderContent() {
     const ext = file.ext;
     const parts = file.name.split('/');
     wsSetToolbar(parts);
+
+    const IMG_EXTS = new Set(['png','jpg','jpeg','gif','webp','svg','ico','bmp']);
+    if (IMG_EXTS.has(ext)) {
+      content.className = 'ws-scroll';
+      content.style.cssText = 'flex:1;min-height:0;overflow:auto;display:flex;align-items:center;justify-content:center;padding:24px;background:color-mix(in srgb,var(--h-ink) 4%,var(--h-bg))';
+      const img = document.createElement('img');
+      img.src = `/api/workspace/file/${encodeURIComponent(file.name)}?room=${currentRoomId}`;
+      img.style.cssText = 'max-width:100%;max-height:100%;object-fit:contain;border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,.12)';
+      img.alt = file.name;
+      content.appendChild(img);
+      return;
+    }
 
     if (ext === 'md' && file.content) {
       content.className = 'ws-scroll ws-md-view';

--- a/index.html
+++ b/index.html
@@ -5357,24 +5357,28 @@ function makeFileLink(codeEl, filePath) {
 }
 
 function openFileFromPath(absOrRelPath) {
-  let relPath = absOrRelPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  let filePath = absOrRelPath.replace(/\\/g, '/').replace(/\/+$/, '');
+  let isAbsolute = /^\//.test(filePath) || /^[A-Za-z]:/.test(filePath);
   if (wsFileTreeRoot) {
     const root = wsFileTreeRoot.replace(/\\/g, '/').replace(/\/+$/, '');
-    if (relPath.startsWith(root + '/')) {
-      relPath = relPath.slice(root.length + 1);
+    if (filePath.startsWith(root + '/')) {
+      filePath = filePath.slice(root.length + 1);
+      isAbsolute = false;
     }
-  }
-  if (/^[A-Za-z]:\//.test(relPath)) {
-    relPath = relPath.replace(/^[A-Za-z]:\//, '');
   }
   const panel = document.getElementById('workspace-panel');
   if (!panel.classList.contains('open')) toggleWorkspacePanel();
-  const ext = wsGetExt(relPath);
+  const ext = wsGetExt(filePath);
   if (!ext) {
-    if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type: 'file_list' }));
+    if (ws && ws.readyState === 1) {
+      ws.send(JSON.stringify(isAbsolute ? { type: 'file_list', abs_path: filePath } : { type: 'file_list' }));
+    }
     wsSetView('files');
   } else {
-    wsOpenFile(relPath);
+    if (isAbsolute && ws && ws.readyState === 1) {
+      ws.send(JSON.stringify({ type: 'file_read', path: filePath, absolute: true }));
+    }
+    wsOpenFile(filePath);
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -5371,7 +5371,7 @@ function openFileFromPath(absOrRelPath) {
   if (!panel.classList.contains('open')) toggleWorkspacePanel();
   const ext = wsGetExt(relPath);
   if (!ext) {
-    if (ws) ws.send(JSON.stringify({ type: 'file_list' }));
+    if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type: 'file_list' }));
     wsSetView('files');
   } else {
     wsOpenFile(relPath);

--- a/index.html
+++ b/index.html
@@ -6414,7 +6414,7 @@ function initScrollLoader() {
   async function doSearch(q) {
     try {
       const res = await fetch(`/api/search?q=${encodeURIComponent(q)}&limit=30`);
-      if (!res.ok) return;
+      if (!res.ok) { showToast('Search failed', { error: true }); return; }
       const rows = await res.json();
       showSearchResults(rows);
     } catch { showToast('Search failed', { error: true }); }
@@ -8487,7 +8487,7 @@ async function sRemoveAvatar() {
     sUpdateAvatarPreview(null);
     renderSidebarFooter();
     renderComposerSeal();
-  } catch (err) { console.error('avatar remove failed', err); }
+  } catch (err) { console.error('avatar remove failed', err); showToast('Failed to remove avatar', { error: true }); }
 }
 
 async function sResizeAndUploadActorAvatar(actorId, file, avEl) {
@@ -8526,7 +8526,7 @@ async function sResizeAndUploadActorAvatar(actorId, file, avEl) {
           if (existing) avEl.replaceChild(imgEl, existing);
           else avEl.prepend(imgEl);
         }
-      } catch (err) { console.error('actor avatar upload failed', err); }
+      } catch (err) { console.error('actor avatar upload failed', err); showToast('Failed to upload avatar', { error: true }); }
     };
     img.src = e.target.result;
   };

--- a/index.html
+++ b/index.html
@@ -4337,6 +4337,7 @@ function connectWS(roomId) {
 
   ws.onopen = () => {
     ws.send(JSON.stringify({ type: 'join_room', room_id: roomId }));
+    ws.send(JSON.stringify({ type: 'file_list' }));
     setConnected(true);
   };
 

--- a/index.html
+++ b/index.html
@@ -784,7 +784,7 @@
     .h-msg-seal-wrap { flex: 0 0 auto; margin-bottom: 2px; }
 
     .h-msg-body {
-      max-width: 560px;
+      max-width: var(--stoa-msg-width, 560px);
       display: flex;
       flex-direction: column;
       gap: 5px;
@@ -829,16 +829,16 @@
     }
     .h-msg-row.ai .h-bubble {
       font-family: var(--h-msg);
-      font-size: 15px;
+      font-size: calc(var(--stoa-msg-scale, 1) * 15px);
       font-weight: 400;
-      line-height: 1.7;
+      line-height: calc(1.7 * var(--stoa-msg-leading, 1));
       border-top-left-radius: 4px;
     }
     .h-msg-row.human .h-bubble {
       font-family: var(--h-msg);
-      font-size: 15px;
+      font-size: calc(var(--stoa-msg-scale, 1) * 15px);
       font-weight: 400;
-      line-height: 1.65;
+      line-height: calc(1.65 * var(--stoa-msg-leading, 1));
       border-top-right-radius: 4px;
     }
 
@@ -1170,6 +1170,45 @@
       transition: background .15s;
     }
     .s-logout-btn:hover { background: #a33; }
+
+    /* ── Reading comfort controls ───────────────────── */
+    .s-msg-section { display: flex; flex-direction: column; gap: 18px; padding: 14px 0 6px; }
+    .s-msg-sublabel {
+      font-family: var(--h-serif); font-style: italic;
+      font-size: 12px; color: var(--h-ink-mute); letter-spacing: .04em; margin-bottom: 2px;
+    }
+    .s-msg-row { display: flex; gap: 8px; }
+    .s-msg-row-wrap { display: flex; gap: 18px; flex-wrap: wrap; }
+    .s-msg-col { flex: 1; min-width: 220px; display: flex; flex-direction: column; gap: 8px; }
+
+    .s-seg-btn {
+      flex: 1; display: flex; flex-direction: column; align-items: center;
+      justify-content: flex-end; gap: 8px; min-height: 62px;
+      padding: 12px 8px 10px; border-radius: 10px; cursor: pointer;
+      background: transparent; border: 1px solid var(--h-hair-soft);
+      color: var(--h-ink-mute); transition: background .12s, border-color .12s, color .12s;
+    }
+    .s-seg-btn:hover { border-color: var(--h-hairline); }
+    .s-seg-btn.active {
+      background: var(--h-surface-hi); border-color: var(--h-ink); color: var(--h-ink);
+    }
+    .s-seg-label { font-family: var(--h-sans); font-size: 11.5px; }
+    .s-seg-icon { font-family: var(--h-serif); line-height: 1; }
+
+    .s-seg-bars { display: flex; flex-direction: column; align-items: center; }
+    .s-seg-bar { width: 16px; height: 2px; border-radius: 2px; background: currentColor; }
+
+    .s-msg-preview {
+      display: flex; flex-direction: column; gap: 12px; padding: 16px; border-radius: 12px;
+      background: color-mix(in srgb, var(--h-bg) 55%, var(--h-surface));
+      border: 1px solid var(--h-hair-soft);
+    }
+    .s-msg-preview-row { display: flex; align-items: flex-end; gap: 10px; }
+    .s-msg-preview-row.human { flex-direction: row-reverse; }
+    .s-msg-preview-bubble {
+      padding: 10px 15px; border-radius: 15px; border: 1px solid;
+      font-family: var(--h-msg); color: var(--h-ink); text-wrap: pretty;
+    }
 
     /* Streaming cursor */
     .h-cursor {
@@ -2938,6 +2977,13 @@
     <!-- tab: general -->
     <div class="s-content" id="s-tab-general" style="display:none">
       <div class="s-content-inner">
+        <div class="s-server-card">
+          <div class="s-server-card-header">
+            <span style="font-family:var(--h-serif);font-size:16px;color:var(--h-ink)">messages</span>
+            <span style="font-family:var(--h-serif);font-style:italic;font-size:13px;color:var(--h-ink-faint)">reading comfort in chat bubbles — applies to every room</span>
+          </div>
+          <div id="s-reading-controls" class="s-msg-section" style="padding:14px 18px 18px"></div>
+        </div>
         <div class="s-server-card">
           <div class="s-server-card-header">
             <span style="font-family:var(--h-serif);font-size:16px;color:var(--h-ink)">account</span>
@@ -5801,6 +5847,14 @@ async function checkSetup() {
 async function init() {
   const saved = localStorage.getItem('stoa-theme');
   applyTheme(saved === 'dark' || (!saved && window.matchMedia('(prefers-color-scheme: dark)').matches));
+  // Restore reading comfort preferences
+  ['scale', 'leading', 'width'].forEach(k => {
+    const v = localStorage.getItem('stoa-msg-' + k);
+    if (v) {
+      const cssVar = '--stoa-msg-' + k;
+      document.documentElement.style.setProperty(cssVar, k === 'width' ? v + 'px' : v);
+    }
+  });
   // Auth check — show login if not authenticated
   const isAuthed = await checkAuth();
   if (!isAuthed) { showLogin(); return; }
@@ -7090,7 +7144,143 @@ async function sOpenDoc(slug) {
   } catch { body.innerHTML = '<p class="s-docs-empty">failed to load document.</p>'; }
 }
 
+// ── Reading comfort controls ──────────────────────────────────────────────
+const MSG_SIZES = [
+  { label: 'Compact', v: 0.9, icon: 17 },
+  { label: 'Cozy', v: 1.0, icon: 20 },
+  { label: 'Comfortable', v: 1.15, icon: 23 },
+  { label: 'Large', v: 1.3, icon: 26 },
+];
+const MSG_LEADS = [
+  { label: 'Tight', v: 0.9, gap: 2 },
+  { label: 'Normal', v: 1.0, gap: 4 },
+  { label: 'Relaxed', v: 1.15, gap: 6 },
+];
+const MSG_WIDTHS = [
+  { label: 'Narrow', v: 460, w: 14 },
+  { label: 'Standard', v: 560, w: 20 },
+  { label: 'Wide', v: 680, w: 26 },
+];
+
+function sGetMsgPref(key, def) {
+  const v = localStorage.getItem('stoa-msg-' + key);
+  return v !== null ? parseFloat(v) : def;
+}
+
+function sApplyMsgVar(cssVar, val, storeKey) {
+  document.documentElement.style.setProperty(cssVar, typeof val === 'number' && val > 100 ? val + 'px' : String(val));
+  localStorage.setItem('stoa-msg-' + storeKey, val);
+}
+
+function sRenderReadingControls() {
+  const el = document.getElementById('s-reading-controls');
+  if (!el) return;
+
+  let scale = sGetMsgPref('scale', 1);
+  let lead = sGetMsgPref('leading', 1);
+  let width = sGetMsgPref('width', 560);
+
+  function nearest(arr, val) { return arr.reduce((b, o) => Math.abs(o.v - val) < Math.abs(b.v - val) ? o : b); }
+
+  function render() {
+    const aSize = nearest(MSG_SIZES, scale);
+    const aLead = nearest(MSG_LEADS, lead);
+    const aWid = nearest(MSG_WIDTHS, width);
+
+    el.innerHTML = '';
+
+    // Text size
+    const sizeLabel = document.createElement('div');
+    sizeLabel.className = 's-msg-sublabel';
+    sizeLabel.textContent = 'text size';
+    el.appendChild(sizeLabel);
+
+    const sizeRow = document.createElement('div');
+    sizeRow.className = 's-msg-row';
+    MSG_SIZES.forEach(o => {
+      const btn = document.createElement('button');
+      btn.className = 's-seg-btn' + (o.label === aSize.label ? ' active' : '');
+      btn.innerHTML = `<span class="s-seg-icon" style="font-size:${o.icon}px">A</span><span class="s-seg-label">${o.label}</span>`;
+      btn.onclick = () => { scale = o.v; sApplyMsgVar('--stoa-msg-scale', o.v, 'scale'); render(); };
+      sizeRow.appendChild(btn);
+    });
+    el.appendChild(sizeRow);
+
+    // Line spacing + width row
+    const wrapRow = document.createElement('div');
+    wrapRow.className = 's-msg-row-wrap';
+
+    // Line spacing
+    const leadCol = document.createElement('div');
+    leadCol.className = 's-msg-col';
+    const leadLabel = document.createElement('div');
+    leadLabel.className = 's-msg-sublabel';
+    leadLabel.textContent = 'line spacing';
+    leadCol.appendChild(leadLabel);
+    const leadRow = document.createElement('div');
+    leadRow.className = 's-msg-row';
+    MSG_LEADS.forEach(o => {
+      const btn = document.createElement('button');
+      btn.className = 's-seg-btn' + (o.label === aLead.label ? ' active' : '');
+      const bars = `<span class="s-seg-bars" style="gap:${o.gap}px"><span class="s-seg-bar"></span><span class="s-seg-bar"></span><span class="s-seg-bar"></span></span>`;
+      btn.innerHTML = `${bars}<span class="s-seg-label">${o.label}</span>`;
+      btn.onclick = () => { lead = o.v; sApplyMsgVar('--stoa-msg-leading', o.v, 'leading'); render(); };
+      leadRow.appendChild(btn);
+    });
+    leadCol.appendChild(leadRow);
+    wrapRow.appendChild(leadCol);
+
+    // Width
+    const widCol = document.createElement('div');
+    widCol.className = 's-msg-col';
+    const widLabel = document.createElement('div');
+    widLabel.className = 's-msg-sublabel';
+    widLabel.textContent = 'width';
+    widCol.appendChild(widLabel);
+    const widRow = document.createElement('div');
+    widRow.className = 's-msg-row';
+    MSG_WIDTHS.forEach(o => {
+      const btn = document.createElement('button');
+      btn.className = 's-seg-btn' + (o.label === aWid.label ? ' active' : '');
+      const bars = `<span class="s-seg-bars" style="gap:3px"><span class="s-seg-bar" style="width:${o.w}px"></span><span class="s-seg-bar" style="width:${o.w}px"></span></span>`;
+      btn.innerHTML = `${bars}<span class="s-seg-label">${o.label}</span>`;
+      btn.onclick = () => { width = o.v; sApplyMsgVar('--stoa-msg-width', o.v, 'width'); render(); };
+      widRow.appendChild(btn);
+    });
+    widCol.appendChild(widRow);
+    wrapRow.appendChild(widCol);
+    el.appendChild(wrapRow);
+
+    // Live preview
+    const preview = document.createElement('div');
+    preview.className = 's-msg-preview';
+
+    const aiRow = document.createElement('div');
+    aiRow.className = 's-msg-preview-row';
+    const aiBubble = document.createElement('div');
+    aiBubble.className = 's-msg-preview-bubble';
+    aiBubble.style.cssText = `max-width:min(var(--stoa-msg-width,560px),78%);font-size:calc(var(--stoa-msg-scale,1)*15px);line-height:calc(1.7*var(--stoa-msg-leading,1));border-top-left-radius:4px;background:color-mix(in srgb,#6f9f8c 16%,var(--h-surface));border-color:color-mix(in srgb,#6f9f8c 36%,var(--h-surface))`;
+    aiBubble.innerHTML = 'The client replays from the last <em>message_state</em> event — not from the last token, so a reconnect never loses the thread.';
+    aiRow.appendChild(aiBubble);
+    preview.appendChild(aiRow);
+
+    const humanRow = document.createElement('div');
+    humanRow.className = 's-msg-preview-row human';
+    const humanBubble = document.createElement('div');
+    humanBubble.className = 's-msg-preview-bubble';
+    humanBubble.style.cssText = `max-width:min(var(--stoa-msg-width,560px),78%);font-size:calc(var(--stoa-msg-scale,1)*15px);line-height:calc(1.55*var(--stoa-msg-leading,1));border-top-right-radius:4px;background:var(--h-slip);border-color:var(--h-hair-soft)`;
+    humanBubble.textContent = 'Got it — that reads much better at this size.';
+    humanRow.appendChild(humanBubble);
+    preview.appendChild(humanRow);
+
+    el.appendChild(preview);
+  }
+
+  render();
+}
+
 async function sLoadGeneralTab() {
+  sRenderReadingControls();
   try {
     const user = await fjson('/api/auth/me');
     document.getElementById('s-auth-email-input').value = user.email || '';

--- a/index.html
+++ b/index.html
@@ -4628,7 +4628,6 @@ function applyTheme(dark) {
 
 function toggleSidebar() {
   const collapsed = document.body.classList.toggle('sidebar-collapsed');
-  localStorage.setItem('stoa-sidebar-collapsed', collapsed ? '1' : '');
   const emptyBtn = document.getElementById('empty-rooms-toggle');
   if (emptyBtn) emptyBtn.style.display = collapsed ? '' : 'none';
   if (currentRoomId) {
@@ -6655,12 +6654,6 @@ async function init() {
       document.documentElement.style.setProperty(cssVar, k === 'width' ? v + 'px' : v);
     }
   });
-  // Restore sidebar collapsed state
-  if (localStorage.getItem('stoa-sidebar-collapsed') === '1') {
-    document.body.classList.add('sidebar-collapsed');
-    const emptyBtn = document.getElementById('empty-rooms-toggle');
-    if (emptyBtn) emptyBtn.style.display = '';
-  }
   document.getElementById('sidebar-collapse-btn').onclick = toggleSidebar;
   document.getElementById('empty-rooms-toggle').onclick = toggleSidebar;
   // Auth check — show login if not authenticated

--- a/index.html
+++ b/index.html
@@ -4748,12 +4748,12 @@ function wsOpenFile(name, content) {
   }
   const imgExts = new Set(['png','jpg','jpeg','gif','webp','svg','ico','bmp']);
   const fileExt = wsGetExt(name);
+  const isAbs = /^\//.test(name) || /^[A-Za-z]:/.test(name);
   if (!content && ws) {
-    if (imgExts.has(fileExt)) {
-      ws.send(JSON.stringify({ type: 'file_read', path: name, binary: true }));
-    } else {
-      ws.send(JSON.stringify({ type: 'file_read', path: name }));
-    }
+    const req = { type: 'file_read', path: name };
+    if (imgExts.has(fileExt)) req.binary = true;
+    if (isAbs) req.absolute = true;
+    ws.send(JSON.stringify(req));
   }
   wsActiveFile = name;
   wsActiveView = 'file';
@@ -4806,11 +4806,12 @@ function wsRenderFileTree(container, nodes, parentPath) {
       nameEl.textContent = node.name;
       row.appendChild(nameEl);
 
-      const filePath = parentPath ? parentPath + '/' + node.name : node.name;
+      const relPath = parentPath ? parentPath + '/' + node.name : node.name;
+      const fullPath = wsFileTreeRoot ? wsFileTreeRoot.replace(/\\/g, '/').replace(/\/+$/, '') + '/' + relPath : relPath;
       row.onclick = () => {
         const panel = document.getElementById('workspace-panel');
         if (!panel.classList.contains('open')) toggleWorkspacePanel();
-        wsOpenFile(filePath);
+        wsOpenFile(fullPath);
       };
       container.appendChild(row);
     }

--- a/index.html
+++ b/index.html
@@ -7535,11 +7535,12 @@ function sMakeRow(actor, flash) {
     });
     langSel.addEventListener('change', async () => {
       try {
-        await fetch(`/api/actors/${actor.id}`, {
+        const r = await fetch(`/api/actors/${actor.id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name: actor.name, lang: langSel.value }),
         });
+        if (!r.ok) throw new Error();
       } catch { showToast('Failed to save language', { error: true }); }
     });
     langRow.appendChild(langLabel); langRow.appendChild(langSel);
@@ -7594,7 +7595,8 @@ function sMakeRow(actor, flash) {
         refresh.disabled = true;
         refresh.style.opacity = '0.4';
         try {
-          await fetch(`/api/actors/${actor.id}/rescan`, { method: 'POST' });
+          const rr = await fetch(`/api/actors/${actor.id}/rescan`, { method: 'POST' });
+          if (!rr.ok) throw new Error();
           setTimeout(() => {
             fjson(`/api/actors/${actor.id}/workdirs`).then(wds => {
               const sub = document.querySelector(`#s-row-${actor.id} .s-agent-sub`);
@@ -7618,7 +7620,7 @@ function sMakeRow(actor, flash) {
         e.stopPropagation();
         upd.disabled = true;
         upd.style.opacity = '0.4';
-        try { await fetch(`/api/actors/${actor.id}/force-update`, { method: 'POST' }); } catch { showToast('Failed to send update command', { error: true }); }
+        try { const fu = await fetch(`/api/actors/${actor.id}/force-update`, { method: 'POST' }); if (!fu.ok) throw new Error(); } catch { showToast('Failed to send update command', { error: true }); }
         setTimeout(() => { upd.disabled = !actor.online; upd.style.opacity = ''; }, 3000);
       });
       acts.appendChild(upd);

--- a/index.html
+++ b/index.html
@@ -4948,9 +4948,6 @@ function wsRenderContent() {
         img.src = `data:${mimeMap[ext] || 'image/png'};base64,${file.base64}`;
       } else {
         img.src = `/api/workspace/file?room=${currentRoomId}&path=${encodeURIComponent(file.name)}`;
-        img.onerror = () => {
-          if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type: 'file_read', path: file.name, binary: true }));
-        };
       }
       img.style.cssText = 'max-width:100%;max-height:100%;object-fit:contain;border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,.12)';
       img.alt = file.name;

--- a/index.html
+++ b/index.html
@@ -2626,6 +2626,9 @@
       background: color-mix(in srgb, var(--h-accent) 18%, oklch(0.550 0.020 55));
     }
 
+    .h-file-link-block { transition: outline .12s; }
+    .h-file-link-block:hover { outline: 1.5px dashed var(--h-accent); outline-offset: -1.5px; }
+
     /* Inline code */
     .h-bubble :not(pre) > code {
       font-family: "Cascadia Code", "Fira Code", Consolas, monospace;
@@ -5312,46 +5315,36 @@ function addCopyButtons(el) {
   });
 }
 
-function linkifyFilePaths(el) {
-  const FILE_RE = /(?:[A-Za-z]:[\\\/]|\.{0,2}[\\\/]|~[\\\/])[\w\-.\\/]+\.\w{1,10}/g;
-  const KNOWN_EXTS = new Set(['js','jsx','ts','tsx','py','md','json','html','css','sql','txt','yml','yaml','toml','sh','ps1','cmd','bat','xml','csv','log','env','cfg','ini','conf','png','jpg','jpeg','gif','webp','svg','ico','bmp','pdf']);
+function looksLikePath(text) {
+  const t = text.trim();
+  if (t.length < 3) return false;
+  const hasSlash = t.includes('/') || t.includes('\\');
+  if (!hasSlash) return false;
+  if (/^https?:\/\//.test(t)) return false;
+  if (/^[A-Za-z]:[\\\/]/.test(t)) return true;
+  if (/^[~.]?[\\\/]/.test(t)) return true;
+  if (/^\/[\w.\-]/.test(t)) return true;
+  return false;
+}
 
-  el.querySelectorAll(':not(pre) > code, p, li, td').forEach(node => {
-    if (node.closest('a') || node.closest('.h-file-link')) return;
-    if (node.tagName === 'CODE') {
-      const text = node.textContent.trim();
-      const ext = (text.match(/\.(\w{1,10})$/) || [])[1];
-      if (!ext || !KNOWN_EXTS.has(ext.toLowerCase())) return;
-      if (text.includes('/') || text.includes('\\') || text.startsWith('.')) {
-        makeFileLink(node, text);
-      }
-      return;
-    }
-    const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
-    const matches = [];
-    let textNode;
-    while ((textNode = walker.nextNode())) {
-      if (textNode.parentElement.closest('a, code, pre, .h-file-link')) continue;
-      let m;
-      FILE_RE.lastIndex = 0;
-      while ((m = FILE_RE.exec(textNode.textContent))) {
-        const ext = (m[0].match(/\.(\w{1,10})$/) || [])[1];
-        if (ext && KNOWN_EXTS.has(ext.toLowerCase())) {
-          matches.push({ node: textNode, start: m.index, end: m.index + m[0].length, path: m[0] });
-        }
-      }
-    }
-    for (let i = matches.length - 1; i >= 0; i--) {
-      const { node: tn, start, end, path: fp } = matches[i];
-      const before = tn.textContent.slice(0, start);
-      const after = tn.textContent.slice(end);
-      const link = document.createElement('span');
-      link.className = 'h-file-link';
-      link.textContent = fp;
-      link.onclick = () => openFileFromPath(fp);
-      tn.textContent = before;
-      tn.parentNode.insertBefore(link, tn.nextSibling);
-      if (after) tn.parentNode.insertBefore(document.createTextNode(after), link.nextSibling);
+function linkifyFilePaths(el) {
+  el.querySelectorAll('code').forEach(node => {
+    if (node.closest('a') || node.classList.contains('h-file-link')) return;
+    const text = node.textContent.trim();
+    if (looksLikePath(text)) makeFileLink(node, text);
+  });
+
+  el.querySelectorAll('pre code').forEach(codeEl => {
+    if (codeEl.closest('.h-file-link')) return;
+    const text = codeEl.textContent.trim();
+    if (looksLikePath(text) && text.split('\n').length <= 2) {
+      const pre = codeEl.closest('pre');
+      pre.style.cursor = 'pointer';
+      pre.classList.add('h-file-link-block');
+      pre.onclick = (e) => {
+        if (e.target.closest('.h-copy-btn')) return;
+        openFileFromPath(text.replace(/\n/g, ''));
+      };
     }
   });
 }
@@ -5363,9 +5356,9 @@ function makeFileLink(codeEl, filePath) {
 }
 
 function openFileFromPath(absOrRelPath) {
-  let relPath = absOrRelPath.replace(/\\/g, '/');
+  let relPath = absOrRelPath.replace(/\\/g, '/').replace(/\/+$/, '');
   if (wsFileTreeRoot) {
-    const root = wsFileTreeRoot.replace(/\\/g, '/').replace(/\/$/, '');
+    const root = wsFileTreeRoot.replace(/\\/g, '/').replace(/\/+$/, '');
     if (relPath.startsWith(root + '/')) {
       relPath = relPath.slice(root.length + 1);
     }
@@ -5375,7 +5368,13 @@ function openFileFromPath(absOrRelPath) {
   }
   const panel = document.getElementById('workspace-panel');
   if (!panel.classList.contains('open')) toggleWorkspacePanel();
-  wsOpenFile(relPath);
+  const ext = wsGetExt(relPath);
+  if (!ext) {
+    wsSetView('files');
+    showToast('Directory path — showing file tree');
+  } else {
+    wsOpenFile(relPath);
+  }
 }
 
 // ── Append message ─────────────────────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -2600,6 +2600,32 @@
 
     .h-bubble hr { border: none; border-top: 1px solid var(--h-hair-soft); margin: 0.7em 0; }
 
+    /* File path links */
+    .h-file-link {
+      cursor: pointer;
+      text-decoration: underline;
+      text-decoration-style: dashed;
+      text-underline-offset: 3px;
+      text-decoration-color: var(--h-accent);
+      transition: background .12s;
+      border-radius: 3px;
+    }
+    .h-file-link:hover {
+      background: color-mix(in srgb, var(--h-accent) 12%, transparent);
+    }
+    code.h-file-link {
+      text-decoration: underline;
+      text-decoration-style: dashed;
+      text-underline-offset: 3px;
+      text-decoration-color: var(--h-accent);
+    }
+    code.h-file-link:hover {
+      background: color-mix(in srgb, var(--h-accent) 18%, oklch(0.820 0.028 50));
+    }
+    html.dark code.h-file-link:hover {
+      background: color-mix(in srgb, var(--h-accent) 18%, oklch(0.550 0.020 55));
+    }
+
     /* Inline code */
     .h-bubble :not(pre) > code {
       font-family: "Cascadia Code", "Fira Code", Consolas, monospace;
@@ -5286,6 +5312,72 @@ function addCopyButtons(el) {
   });
 }
 
+function linkifyFilePaths(el) {
+  const FILE_RE = /(?:[A-Za-z]:[\\\/]|\.{0,2}[\\\/]|~[\\\/])[\w\-.\\/]+\.\w{1,10}/g;
+  const KNOWN_EXTS = new Set(['js','jsx','ts','tsx','py','md','json','html','css','sql','txt','yml','yaml','toml','sh','ps1','cmd','bat','xml','csv','log','env','cfg','ini','conf','png','jpg','jpeg','gif','webp','svg','ico','bmp','pdf']);
+
+  el.querySelectorAll(':not(pre) > code, p, li, td').forEach(node => {
+    if (node.closest('a') || node.closest('.h-file-link')) return;
+    if (node.tagName === 'CODE') {
+      const text = node.textContent.trim();
+      const ext = (text.match(/\.(\w{1,10})$/) || [])[1];
+      if (!ext || !KNOWN_EXTS.has(ext.toLowerCase())) return;
+      if (text.includes('/') || text.includes('\\') || text.startsWith('.')) {
+        makeFileLink(node, text);
+      }
+      return;
+    }
+    const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+    const matches = [];
+    let textNode;
+    while ((textNode = walker.nextNode())) {
+      if (textNode.parentElement.closest('a, code, pre, .h-file-link')) continue;
+      let m;
+      FILE_RE.lastIndex = 0;
+      while ((m = FILE_RE.exec(textNode.textContent))) {
+        const ext = (m[0].match(/\.(\w{1,10})$/) || [])[1];
+        if (ext && KNOWN_EXTS.has(ext.toLowerCase())) {
+          matches.push({ node: textNode, start: m.index, end: m.index + m[0].length, path: m[0] });
+        }
+      }
+    }
+    for (let i = matches.length - 1; i >= 0; i--) {
+      const { node: tn, start, end, path: fp } = matches[i];
+      const before = tn.textContent.slice(0, start);
+      const after = tn.textContent.slice(end);
+      const link = document.createElement('span');
+      link.className = 'h-file-link';
+      link.textContent = fp;
+      link.onclick = () => openFileFromPath(fp);
+      tn.textContent = before;
+      tn.parentNode.insertBefore(link, tn.nextSibling);
+      if (after) tn.parentNode.insertBefore(document.createTextNode(after), link.nextSibling);
+    }
+  });
+}
+
+function makeFileLink(codeEl, filePath) {
+  codeEl.classList.add('h-file-link');
+  codeEl.style.cursor = 'pointer';
+  codeEl.onclick = (e) => { e.preventDefault(); openFileFromPath(filePath); };
+}
+
+function openFileFromPath(absOrRelPath) {
+  let relPath = absOrRelPath.replace(/\\/g, '/');
+  if (wsFileTreeRoot) {
+    const root = wsFileTreeRoot.replace(/\\/g, '/').replace(/\/$/, '');
+    if (relPath.startsWith(root + '/')) {
+      relPath = relPath.slice(root.length + 1);
+    }
+  }
+  if (/^[A-Za-z]:\//.test(relPath)) {
+    relPath = relPath.replace(/^[A-Za-z]:\//, '');
+  }
+  const panel = document.getElementById('workspace-panel');
+  if (!panel.classList.contains('open')) toggleWorkspacePanel();
+  wsOpenFile(relPath);
+}
+
 // ── Append message ─────────────────────────────────────────────────────────
 function appendMessage(m, container) {
   const inner = container || document.getElementById('messages-inner');
@@ -5379,6 +5471,7 @@ function appendMessage(m, container) {
   row.appendChild(body);
   inner.appendChild(row);
   addCopyButtons(bubble);
+  linkifyFilePaths(bubble);
 }
 
 // ── Thinking bubble (before tokens arrive) ─────────────────────────────────
@@ -5511,6 +5604,7 @@ function finalizeMessage(msgId, content, fileUrl, fileName, attachments) {
     textDiv.innerHTML = highlightMentions(renderMarkdown(content || ''));
     bubble.appendChild(textDiv);
     addCopyButtons(bubble);
+  linkifyFilePaths(bubble);
   }
 
   // Add message action buttons (reply + copy) if not already present

--- a/index.html
+++ b/index.html
@@ -509,102 +509,382 @@
     }
 
     /* ── Dev workspace panel ─────────────────────────────── */
+    .ws-mono { font-family: "Cascadia Code", "Fira Code", "JetBrains Mono", ui-monospace, Consolas, monospace; }
+    .ws-code { background: oklch(0.193 0.016 44); color: #d3c8b4; }
+    .ws-code .hljs { background: transparent; color: #d3c8b4; }
+    .ws-code::-webkit-scrollbar { width: 8px; height: 8px; }
+    .ws-code::-webkit-scrollbar-thumb { background: rgba(255,255,255,.12); border-radius: 4px; }
+    .ws-code::-webkit-scrollbar-track { background: transparent; }
+    .ws-scroll::-webkit-scrollbar { width: 8px; height: 8px; }
+    .ws-scroll::-webkit-scrollbar-thumb { background: var(--h-hair-soft); border-radius: 4px; }
+    .ws-scroll::-webkit-scrollbar-track { background: transparent; }
+
     #workspace-panel {
       display: none;
-      flex-direction: column;
-      width: var(--ws-panel-width, 40%);
+      flex-direction: row;
+      width: var(--ws-panel-width, 560px);
       min-width: 280px;
       max-width: 70%;
-      background: var(--h-bg);
-      border-left: 1px solid var(--h-hairline);
       overflow: hidden;
     }
     #workspace-panel.open { display: flex; }
 
     #ws-drag-handle {
-      position: absolute;
-      left: -3px;
-      top: 0;
-      bottom: 0;
-      width: 6px;
-      cursor: col-resize;
-      z-index: 10;
-      background: transparent;
-      transition: background 0.15s;
-    }
-    #ws-drag-handle:hover, #ws-drag-handle.dragging {
-      background: var(--h-accent);
-      opacity: 0.4;
-    }
-    #ws-drag-handle.dragging { opacity: 0.6; }
-
-    #ws-panel-header {
-      padding: 12px 16px;
-      border-bottom: 1px solid var(--h-hair-soft);
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      background: var(--h-header-bg);
+      width: 7px;
       flex: 0 0 auto;
-    }
-
-    #ws-panel-title {
-      font-family: var(--h-serif);
-      font-size: 14px;
-      color: var(--h-ink);
-    }
-
-    .ws-panel-close {
-      background: none;
-      border: none;
-      cursor: pointer;
-      color: var(--h-ink-faint);
-      padding: 4px;
-      border-radius: 6px;
+      cursor: col-resize;
+      position: relative;
+      background: var(--h-bg);
+      border-left: 1px solid var(--h-hairline);
       display: flex;
       align-items: center;
       justify-content: center;
-      transition: color 0.12s, background 0.12s;
     }
-    .ws-panel-close:hover { color: var(--h-ink); background: var(--h-surface); }
+    .ws-grip {
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      opacity: .5;
+      transition: opacity .12s;
+    }
+    #ws-drag-handle:hover .ws-grip, #ws-drag-handle.dragging .ws-grip { opacity: 1; }
+    .ws-grip-dot {
+      width: 3px;
+      height: 3px;
+      border-radius: 50%;
+      background: var(--h-ink-faint);
+    }
 
-    #ws-panel-content {
+    #ws-panel-body {
+      flex: 1;
+      min-width: 0;
+      background: var(--h-bg);
+      display: flex;
+      flex-direction: column;
+    }
+
+    /* ── Tab bar ───────────────────────────────────── */
+    .ws-tab-bar {
+      display: flex;
+      align-items: stretch;
+      height: 42px;
+      flex: 0 0 auto;
+      background: var(--h-header-bg);
+      border-bottom: 1px solid var(--h-hairline);
+    }
+    .ws-pin-tab {
+      position: relative;
+      width: 40px;
+      border: none;
+      cursor: pointer;
+      background: transparent;
+      color: var(--h-ink-mute);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: background .12s, color .12s;
+    }
+    .ws-pin-tab:hover { color: var(--h-ink); }
+    .ws-pin-tab.active { background: var(--h-bg); color: var(--h-ink); }
+    .ws-pin-tab .ws-tab-indicator {
+      position: absolute;
+      left: 8px; right: 8px; bottom: 0;
+      height: 2px; background: var(--h-ink); border-radius: 2px;
+      display: none;
+    }
+    .ws-pin-tab.active .ws-tab-indicator { display: block; }
+
+    .ws-tab-divider { width: 1px; background: var(--h-hair-soft); margin: 8px 4px; }
+
+    .ws-tab-list {
+      display: flex;
+      align-items: stretch;
+      overflow: hidden;
+      flex: 1;
+    }
+    .ws-file-tab {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 10px 0 12px;
+      cursor: pointer;
+      max-width: 180px;
+      flex: 0 0 auto;
+      background: transparent;
+      border: none;
+      border-right: 1px solid var(--h-hair-soft);
+      transition: background .12s;
+    }
+    .ws-file-tab:hover { background: color-mix(in srgb, var(--h-surface) 50%, transparent); }
+    .ws-file-tab.active { background: var(--h-bg); }
+    .ws-file-tab .ws-tab-indicator {
+      position: absolute;
+      left: 10px; right: 10px; bottom: 0;
+      height: 2px; background: var(--h-ink); border-radius: 2px;
+      display: none;
+    }
+    .ws-file-tab.active .ws-tab-indicator { display: block; }
+    .ws-file-tab-name {
+      font-family: var(--h-sans);
+      font-size: 12px;
+      color: var(--h-ink-mute);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .ws-file-tab.active .ws-file-tab-name { color: var(--h-ink); }
+    .ws-file-tab-modified { color: var(--h-ink-faint); }
+    .ws-file-tab-close {
+      opacity: 0;
+      transition: opacity .12s;
+      color: var(--h-ink-mute);
+      display: inline-flex;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 0;
+    }
+    .ws-file-tab:hover .ws-file-tab-close,
+    .ws-file-tab.active .ws-file-tab-close { opacity: .7; }
+    .ws-file-tab-close:hover { opacity: 1 !important; }
+
+    .ws-tab-overflow {
+      flex: 0 0 auto;
+      width: 30px;
+      border: none;
+      background: transparent;
+      color: var(--h-ink-mute);
+      cursor: pointer;
+      border-left: 1px solid var(--h-hair-soft);
+      font-size: 16px;
+    }
+    .ws-tab-close-panel {
+      flex: 0 0 auto;
+      width: 38px;
+      border: none;
+      background: transparent;
+      color: var(--h-ink-mute);
+      cursor: pointer;
+      border-left: 1px solid var(--h-hair-soft);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: color .12s;
+    }
+    .ws-tab-close-panel:hover { color: var(--h-ink); }
+
+    /* ── File glyph ───────────────────────────────── */
+    .ws-file-glyph {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 3px;
+      font-size: 7.5px;
+      font-weight: 600;
+      letter-spacing: .02em;
+    }
+
+    /* ── Panel toolbar ────────────────────────────── */
+    .ws-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex: 0 0 auto;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--h-hair-soft);
+      background: var(--h-bg);
+    }
+    .ws-breadcrumb {
       flex: 1;
       display: flex;
       align-items: center;
-      justify-content: center;
-      overflow: auto;
+      gap: 6px;
+      min-width: 0;
+      overflow: hidden;
+    }
+    .ws-crumb {
+      font-family: var(--h-sans);
+      font-size: 11px;
+      white-space: nowrap;
+      color: var(--h-ink-faint);
+    }
+    .ws-crumb:last-child { color: var(--h-ink-mute); }
+    .ws-crumb-sep { color: var(--h-ink-faint); font-size: 11px; }
+
+    .ws-ghost-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: 7px;
+      cursor: pointer;
+      font-family: var(--h-sans);
+      font-size: 11.5px;
+      color: var(--h-ink-mute);
+      background: transparent;
+      border: 1px solid var(--h-hair-soft);
+      transition: all .12s;
+    }
+    .ws-ghost-btn:hover { border-color: var(--h-hairline); color: var(--h-ink); }
+    .ws-ghost-btn.active {
+      color: var(--h-ink);
+      background: var(--h-surface-hi);
+      border-color: var(--h-hairline);
     }
 
+    /* ── Empty panel ──────────────────────────────── */
     .ws-empty-state {
+      flex: 1;
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 14px;
+      padding: 32px;
       text-align: center;
-      padding: 40px 24px;
     }
-    .ws-empty-icon { color: var(--h-ink-faint); opacity: 0.4; margin-bottom: 16px; }
-    .ws-empty-text {
+    .ws-empty-icon { color: var(--h-ink-faint); opacity: .8; }
+    .ws-empty-title {
       font-family: var(--h-serif);
-      font-style: italic;
-      font-size: 14px;
+      font-size: 18px;
+      color: var(--h-ink-mute);
+    }
+    .ws-empty-text {
+      font-family: var(--h-sans);
+      font-size: 13px;
       color: var(--h-ink-faint);
-      line-height: 1.5;
+      line-height: 1.55;
       max-width: 240px;
     }
 
-    .h-ws-toggle {
-      background: none;
-      border: none;
-      cursor: pointer;
-      color: var(--h-ink-faint);
-      padding: 4px;
-      border-radius: 6px;
+    /* ── File tree ────────────────────────────────── */
+    .ws-tree { flex: 1; min-height: 0; overflow: auto; padding: 8px 6px; }
+    .ws-tree-row {
       display: flex;
       align-items: center;
-      justify-content: center;
-      transition: color 0.12s, background 0.12s;
-      margin-left: 8px;
+      gap: 7px;
+      padding: 5px 8px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background .12s;
     }
-    .h-ws-toggle:hover { color: var(--h-ink); background: var(--h-surface-hi); }
-    .h-ws-toggle.active { color: var(--h-accent); }
+    .ws-tree-row:hover { background: var(--h-surface-hi); }
+    .ws-tree-row.active { background: var(--h-surface); }
+    .ws-tree-chevron {
+      color: var(--h-ink-faint);
+      display: inline-flex;
+      transition: transform .12s;
+    }
+    .ws-tree-chevron.open { transform: rotate(90deg); }
+    .ws-tree-name {
+      flex: 1;
+      min-width: 0;
+      font-family: var(--h-sans);
+      font-size: 13px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .ws-tree-name.folder { font-weight: 500; color: var(--h-ink); }
+    .ws-tree-name.file { font-weight: 400; color: var(--h-ink-mute); }
+    .ws-tree-name.active { color: var(--h-ink); }
+    .ws-tree-modified {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      flex: 0 0 auto;
+    }
+
+    /* ── Code viewer ──────────────────────────────── */
+    .ws-code-viewer {
+      flex: 1;
+      min-height: 0;
+      overflow: auto;
+      font-size: 13px;
+      line-height: 21px;
+    }
+    .ws-code-table { display: table; min-width: 100%; }
+    .ws-code-line { display: table-row; }
+    .ws-code-line.active { background: rgba(255,255,255,.045); }
+    .ws-code-gutter {
+      display: table-cell;
+      text-align: right;
+      padding: 0 12px 0 14px;
+      color: #7a7060;
+      user-select: none;
+      border-right: 1px solid rgba(255,255,255,.07);
+    }
+    .ws-code-line.active .ws-code-gutter { color: #d3c8b4; }
+    .ws-code-text {
+      display: table-cell;
+      padding: 0 18px 0 16px;
+      white-space: pre;
+    }
+
+    /* ── Diff viewer ──────────────────────────────── */
+    .ws-diff-file-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex: 0 0 auto;
+      padding: 9px 14px;
+      border-bottom: 1px solid var(--h-hair-soft);
+      background: var(--h-surface);
+    }
+    .ws-diff-stat { display: inline-flex; align-items: center; gap: 6px; font-family: var(--h-sans); font-size: 11px; font-weight: 500; }
+    .ws-diff-add { color: #7faa7c; }
+    .ws-diff-del { color: #c08378; }
+
+    .ws-diff-hunk {
+      display: table-row;
+    }
+    .ws-diff-hunk-text {
+      display: table-cell;
+      padding: 3px 14px;
+      color: #7d93b0;
+      background: rgba(91,143,212,.08);
+      white-space: pre;
+    }
+    .ws-diff-line-add { background: color-mix(in srgb, oklch(0.62 0.10 150) 16%, oklch(0.193 0.016 44)); }
+    .ws-diff-line-del { background: color-mix(in srgb, oklch(0.58 0.12 28) 16%, oklch(0.193 0.016 44)); }
+    .ws-diff-line-empty { background: rgba(0,0,0,.18); }
+
+    /* ── Editing banner ───────────────────────────── */
+    .ws-editing-banner {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      flex: 0 0 auto;
+      padding: 8px 14px;
+      font-family: var(--h-sans);
+      font-size: 12.5px;
+      font-style: italic;
+    }
+
+    /* ── Toggle button ────────────────────────────── */
+    .h-ws-toggle {
+      width: 34px;
+      height: 34px;
+      border-radius: 9px;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--h-hair-soft);
+      background: transparent;
+      color: var(--h-ink-mute);
+      margin-left: 6px;
+      transition: color .12s, background .12s, border-color .12s;
+    }
+    .h-ws-toggle:hover { color: var(--h-ink); border-color: var(--h-hairline); }
+    .h-ws-toggle.active {
+      color: var(--h-ink);
+      background: var(--h-surface-hi);
+      border-color: var(--h-hairline);
+    }
 
     @media (max-width: 1200px) {
       #workspace-panel.open {
@@ -3149,23 +3429,43 @@
   </div>
 </div><!-- /chat-area -->
 
-<div id="workspace-panel" style="position:relative">
-  <div id="ws-drag-handle"></div>
-  <div id="ws-panel-header">
-    <span id="ws-panel-title">workspace</span>
-    <button class="ws-panel-close" id="ws-panel-close-btn" title="Close panel">
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-    </button>
+<div id="workspace-panel">
+  <div id="ws-drag-handle">
+    <span class="ws-grip">
+      <span class="ws-grip-dot"></span>
+      <span class="ws-grip-dot"></span>
+      <span class="ws-grip-dot"></span>
+    </span>
   </div>
-  <div id="ws-panel-content">
-    <div class="ws-empty-state">
-      <div class="ws-empty-icon">
-        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M13 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/>
-          <polyline points="13 2 13 9 20 9"/>
-        </svg>
+  <div id="ws-panel-body">
+    <div class="ws-tab-bar" id="ws-tab-bar">
+      <button class="ws-pin-tab active" data-ws-pin="files" title="Files">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h7M4 12h10M4 18h6"/><circle cx="18" cy="6" r="1.4" fill="currentColor" stroke="none"/></svg>
+        <span class="ws-tab-indicator"></span>
+      </button>
+      <button class="ws-pin-tab" data-ws-pin="git" title="Git">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="6.5" cy="6" r="2.2"/><circle cx="6.5" cy="18" r="2.2"/><circle cx="17.5" cy="8" r="2.2"/><path d="M6.5 8.2v7.6M8.7 8c4 .2 6.5 1 8.6 .2M17.5 10.2c0 3.2-3 4.6-6.2 4.8"/></svg>
+        <span class="ws-tab-indicator"></span>
+      </button>
+      <div class="ws-tab-divider"></div>
+      <div class="ws-tab-list" id="ws-tab-list"></div>
+      <button class="ws-tab-close-panel" id="ws-panel-close-btn" title="Close panel">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"/></svg>
+      </button>
+    </div>
+    <div id="ws-editing-banner"></div>
+    <div class="ws-toolbar" id="ws-toolbar" style="display:none">
+      <div class="ws-breadcrumb" id="ws-breadcrumb"></div>
+      <div id="ws-toolbar-actions"></div>
+    </div>
+    <div id="ws-panel-content">
+      <div class="ws-empty-state">
+        <span class="ws-empty-icon">
+          <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h7M4 12h10M4 18h6"/><circle cx="18" cy="6" r="1.4" fill="currentColor" stroke="none"/></svg>
+        </span>
+        <div class="ws-empty-title">nothing open yet</div>
+        <div class="ws-empty-text">open a file, or click a file reference in the chat to read it here.</div>
       </div>
-      <div class="ws-empty-text">open a file or click a file reference in chat.</div>
     </div>
   </div>
 </div><!-- /workspace-panel -->
@@ -3649,9 +3949,9 @@ function renderChatHeader(room, participants) {
   header.appendChild(exportWrap);
 
   const wsToggle = document.createElement('button');
-  wsToggle.className = 'h-ws-toggle h-header-action-btn' + (document.getElementById('workspace-panel').classList.contains('open') ? ' active' : '');
+  wsToggle.className = 'h-ws-toggle' + (document.getElementById('workspace-panel').classList.contains('open') ? ' active' : '');
   wsToggle.title = 'Dev Workspace';
-  wsToggle.innerHTML = `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="12" y1="3" x2="12" y2="21"/><line x1="12" y1="9" x2="21" y2="9"/></svg>`;
+  wsToggle.innerHTML = `<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.5"/><path d="M14 4v16"/></svg>`;
   wsToggle.onclick = toggleWorkspacePanel;
   header.appendChild(wsToggle);
 }
@@ -4178,6 +4478,34 @@ function toggleTheme() {
 }
 
 // ── Workspace panel ───────────────────────────────────────────────────────
+const WS_FILE_COLORS = {
+  js:   { tag: 'js',  c: '#c2876b' },
+  jsx:  { tag: 'jsx', c: '#6f9f8c' },
+  ts:   { tag: 'ts',  c: '#5b8fd4' },
+  tsx:  { tag: 'tsx', c: '#5b8fd4' },
+  md:   { tag: 'md',  c: '#5b8fd4' },
+  json: { tag: '{}',  c: '#d39749' },
+  css:  { tag: 'css', c: '#c08aa0' },
+  html: { tag: 'htm', c: '#c2876b' },
+  py:   { tag: 'py',  c: '#b59a5e' },
+  sql:  { tag: 'sql', c: '#6f9f8c' },
+};
+
+function wsFileGlyph(ext, size = 15) {
+  const m = WS_FILE_COLORS[ext] || { tag: '', c: 'var(--h-ink-faint)' };
+  const el = document.createElement('span');
+  el.className = 'ws-file-glyph ws-mono';
+  el.style.cssText = `width:${size+3}px;height:${size+3}px;border:1px solid color-mix(in srgb,${m.c} 50%,transparent);background:color-mix(in srgb,${m.c} 14%,transparent);color:${m.c}`;
+  el.textContent = m.tag;
+  return el;
+}
+
+function wsGetExt(name) { return (name.match(/\.(\w+)$/) || [])[1] || ''; }
+
+let wsActiveView = 'files';
+let wsOpenFiles = [];
+let wsActiveFile = null;
+
 function toggleWorkspacePanel() {
   const panel = document.getElementById('workspace-panel');
   const isOpen = panel.classList.toggle('open');
@@ -4188,12 +4516,220 @@ function toggleWorkspacePanel() {
   }
 }
 
+function wsSetView(view) {
+  wsActiveView = view;
+  document.querySelectorAll('.ws-pin-tab').forEach(t => {
+    t.classList.toggle('active', t.dataset.wsPin === view);
+  });
+  wsRenderContent();
+}
+
+function wsOpenFile(name, content) {
+  if (!wsOpenFiles.find(f => f.name === name)) {
+    wsOpenFiles.push({ name, content: content || '', ext: wsGetExt(name) });
+  }
+  wsActiveFile = name;
+  wsActiveView = 'file';
+  document.querySelectorAll('.ws-pin-tab').forEach(t => t.classList.remove('active'));
+  wsRenderTabs();
+  wsRenderContent();
+}
+
+function wsCloseFile(name) {
+  wsOpenFiles = wsOpenFiles.filter(f => f.name !== name);
+  if (wsActiveFile === name) {
+    wsActiveFile = wsOpenFiles.length ? wsOpenFiles[wsOpenFiles.length - 1].name : null;
+    if (!wsActiveFile) wsActiveView = 'files';
+  }
+  wsRenderTabs();
+  wsRenderContent();
+}
+
+function wsRenderTabs() {
+  const list = document.getElementById('ws-tab-list');
+  if (!list) return;
+  list.innerHTML = '';
+  wsOpenFiles.forEach(f => {
+    const tab = document.createElement('div');
+    tab.className = 'ws-file-tab' + (f.name === wsActiveFile ? ' active' : '');
+    tab.appendChild(wsFileGlyph(f.ext, 13));
+    const nameEl = document.createElement('span');
+    nameEl.className = 'ws-file-tab-name';
+    nameEl.textContent = f.name;
+    tab.appendChild(nameEl);
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'ws-file-tab-close';
+    closeBtn.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"><path d="M6 6l12 12M18 6L6 18"/></svg>';
+    closeBtn.onclick = (e) => { e.stopPropagation(); wsCloseFile(f.name); };
+    tab.appendChild(closeBtn);
+    const indicator = document.createElement('span');
+    indicator.className = 'ws-tab-indicator';
+    tab.appendChild(indicator);
+    tab.onclick = () => wsOpenFile(f.name, f.content);
+    list.appendChild(tab);
+  });
+}
+
+function wsSetToolbar(crumbs, actions) {
+  const toolbar = document.getElementById('ws-toolbar');
+  const bc = document.getElementById('ws-breadcrumb');
+  const act = document.getElementById('ws-toolbar-actions');
+  if (!crumbs || !crumbs.length) { toolbar.style.display = 'none'; return; }
+  toolbar.style.display = '';
+  bc.innerHTML = '';
+  crumbs.forEach((c, i) => {
+    if (i > 0) {
+      const sep = document.createElement('span');
+      sep.className = 'ws-crumb-sep';
+      sep.textContent = '/';
+      bc.appendChild(sep);
+    }
+    const s = document.createElement('span');
+    s.className = 'ws-crumb';
+    s.textContent = c;
+    bc.appendChild(s);
+  });
+  act.innerHTML = '';
+  if (actions) act.appendChild(actions);
+}
+
+function wsRenderContent() {
+  const content = document.getElementById('ws-panel-content');
+  const banner = document.getElementById('ws-editing-banner');
+  content.innerHTML = '';
+  banner.innerHTML = '';
+
+  if (wsActiveView === 'files') {
+    wsSetToolbar(null);
+    content.innerHTML = `<div class="ws-empty-state">
+      <span class="ws-empty-icon"><svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h7M4 12h10M4 18h6"/><circle cx="18" cy="6" r="1.4" fill="currentColor" stroke="none"/></svg></span>
+      <div class="ws-empty-title">nothing open yet</div>
+      <div class="ws-empty-text">open a file, or click a file reference in the chat to read it here.</div>
+    </div>`;
+    return;
+  }
+
+  if (wsActiveView === 'git') {
+    wsSetToolbar(['working tree']);
+    content.innerHTML = `<div class="ws-empty-state">
+      <span class="ws-empty-icon"><svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="6.5" cy="6" r="2.2"/><circle cx="6.5" cy="18" r="2.2"/><circle cx="17.5" cy="8" r="2.2"/><path d="M6.5 8.2v7.6M8.7 8c4 .2 6.5 1 8.6 .2M17.5 10.2c0 3.2-3 4.6-6.2 4.8"/></svg></span>
+      <div class="ws-empty-title">no changes</div>
+      <div class="ws-empty-text">git diff data will appear here when the backend is connected.</div>
+    </div>`;
+    return;
+  }
+
+  if (wsActiveView === 'file' && wsActiveFile) {
+    const file = wsOpenFiles.find(f => f.name === wsActiveFile);
+    if (!file) return;
+    const ext = file.ext;
+    const parts = file.name.split('/');
+    wsSetToolbar(parts);
+
+    if (ext === 'md' && file.content) {
+      content.className = 'ws-scroll';
+      content.style.cssText = 'flex:1;min-height:0;overflow:auto;padding:26px 30px 40px';
+      const inner = document.createElement('div');
+      inner.style.maxWidth = '620px';
+      inner.innerHTML = DOMPurify.sanitize(marked.parse(file.content), { ADD_ATTR: ['class'] });
+      content.appendChild(inner);
+    } else if (file.content) {
+      wsRenderCodeViewer(content, file.content);
+    } else {
+      content.innerHTML = `<div class="ws-empty-state">
+        <div class="ws-empty-title">file viewer</div>
+        <div class="ws-empty-text">file content will load when the backend file:read API is connected.</div>
+      </div>`;
+    }
+  }
+}
+
+function wsRenderCodeViewer(container, text) {
+  const lines = text.split('\n');
+  const gutW = String(lines.length).length * 9 + 22;
+  container.className = 'ws-code ws-mono ws-code-viewer';
+  container.style.cssText = '';
+  const table = document.createElement('div');
+  table.className = 'ws-code-table';
+  lines.forEach((ln, i) => {
+    const row = document.createElement('div');
+    row.className = 'ws-code-line';
+    const gutter = document.createElement('span');
+    gutter.className = 'ws-code-gutter';
+    gutter.style.cssText = `width:${gutW}px;min-width:${gutW}px`;
+    gutter.textContent = i + 1;
+    row.appendChild(gutter);
+    const code = document.createElement('span');
+    code.className = 'ws-code-text';
+    code.textContent = ln || ' ';
+    row.appendChild(code);
+    table.appendChild(row);
+  });
+  container.appendChild(table);
+}
+
+function wsRenderDiff(container, diffData, mode) {
+  const table = document.createElement('div');
+  table.className = 'ws-code-table';
+  diffData.forEach(r => {
+    if (r.k === 'hunk') {
+      const row = document.createElement('div');
+      row.className = 'ws-diff-hunk';
+      const cell = document.createElement('span');
+      cell.className = 'ws-diff-hunk-text';
+      cell.textContent = r.text;
+      row.appendChild(cell);
+      table.appendChild(row);
+      return;
+    }
+    const row = document.createElement('div');
+    row.className = 'ws-code-line' + (r.k === 'add' ? ' ws-diff-line-add' : r.k === 'del' ? ' ws-diff-line-del' : '');
+    const g1 = document.createElement('span');
+    g1.className = 'ws-code-gutter';
+    g1.style.cssText = 'width:34px;padding:0 6px';
+    g1.textContent = r.n1 || '';
+    row.appendChild(g1);
+    const g2 = document.createElement('span');
+    g2.className = 'ws-code-gutter';
+    g2.style.cssText = 'width:34px;padding:0 6px';
+    g2.textContent = r.n2 || '';
+    row.appendChild(g2);
+    const sign = document.createElement('span');
+    sign.style.cssText = 'display:table-cell;width:18px;text-align:center;user-select:none;color:' + (r.k === 'add' ? '#7faa7c' : r.k === 'del' ? '#c08378' : '#7a7060');
+    sign.textContent = r.k === 'add' ? '+' : r.k === 'del' ? '−' : '';
+    row.appendChild(sign);
+    const code = document.createElement('span');
+    code.className = 'ws-code-text';
+    code.style.padding = '0 16px 0 4px';
+    code.textContent = r.text;
+    row.appendChild(code);
+    table.appendChild(row);
+  });
+  container.className = 'ws-code ws-mono ws-code-viewer';
+  container.appendChild(table);
+}
+
+function wsShowEditingBanner(actorName, actorColor) {
+  const banner = document.getElementById('ws-editing-banner');
+  banner.innerHTML = '';
+  if (!actorName) return;
+  const el = document.createElement('div');
+  el.className = 'ws-editing-banner';
+  el.style.cssText = `background:color-mix(in srgb,${actorColor} 14%,var(--h-bg));border-bottom:1px solid color-mix(in srgb,${actorColor} 36%,var(--h-bg));color:${actorColor}`;
+  el.innerHTML = `<span class="h-dot"></span><span class="h-dot"></span><span class="h-dot"></span><span style="font-style:italic">${actorName} is editing this file…</span>`;
+  banner.appendChild(el);
+}
+
 (function initWorkspacePanel() {
   const panel = document.getElementById('workspace-panel');
   const handle = document.getElementById('ws-drag-handle');
   const closeBtn = document.getElementById('ws-panel-close-btn');
 
   closeBtn.onclick = toggleWorkspacePanel;
+
+  document.querySelectorAll('.ws-pin-tab').forEach(tab => {
+    tab.onclick = () => wsSetView(tab.dataset.wsPin);
+  });
 
   let dragging = false;
   let startX = 0;

--- a/index.html
+++ b/index.html
@@ -2180,22 +2180,24 @@
       color: oklch(0.150 0.010 45);
     }
 
-    /* ── Syntax highlighting (warm Stoa palette) ── */
-    .hljs { background: transparent; color: oklch(0.875 0.010 55); }
-    .hljs-keyword, .hljs-selector-tag, .hljs-built_in, .hljs-deletion { color: oklch(0.72 0.12 25); }
-    .hljs-string, .hljs-attr, .hljs-addition { color: oklch(0.72 0.11 145); }
-    .hljs-number, .hljs-literal, .hljs-variable.constant_ { color: oklch(0.75 0.10 70); }
-    .hljs-comment, .hljs-quote { color: oklch(0.52 0.015 55); font-style: italic; }
-    .hljs-function .hljs-title, .hljs-title.function_, .hljs-title.class_ { color: oklch(0.78 0.10 220); }
-    .hljs-type, .hljs-params { color: oklch(0.75 0.08 200); }
-    .hljs-property, .hljs-attribute { color: oklch(0.78 0.06 70); }
-    .hljs-regexp, .hljs-link { color: oklch(0.70 0.12 35); }
-    .hljs-meta, .hljs-tag { color: oklch(0.65 0.06 55); }
-    .hljs-name, .hljs-selector-class, .hljs-selector-id { color: oklch(0.72 0.10 25); }
-    .hljs-symbol, .hljs-bullet { color: oklch(0.72 0.11 145); }
-    .hljs-template-variable, .hljs-subst { color: oklch(0.80 0.08 50); }
+    /* ── Syntax highlighting (Hearth palette — matches workspace.jsx SYN) ── */
+    .hljs { background: transparent; color: #d3c8b4; }
+    .hljs-keyword, .hljs-selector-tag, .hljs-built_in { color: #c2876b; }
+    .hljs-string, .hljs-attr, .hljs-addition { color: #b59a5e; }
+    .hljs-number, .hljs-literal, .hljs-variable.constant_ { color: #c08aa0; }
+    .hljs-comment, .hljs-quote { color: #837868; font-style: italic; }
+    .hljs-function .hljs-title, .hljs-title.function_, .hljs-title.class_ { color: #6f9f8c; }
+    .hljs-type, .hljs-params { color: #6f9f8c; }
+    .hljs-property, .hljs-attribute { color: #d3c8b4; }
+    .hljs-regexp, .hljs-link { color: #c2876b; }
+    .hljs-meta, .hljs-tag { color: #9a8f7e; }
+    .hljs-name, .hljs-selector-class, .hljs-selector-id { color: #c2876b; }
+    .hljs-symbol, .hljs-bullet { color: #b59a5e; }
+    .hljs-template-variable, .hljs-subst { color: #d3c8b4; }
+    .hljs-deletion { color: #c08378; }
     .hljs-emphasis { font-style: italic; }
     .hljs-strong { font-weight: 600; }
+    .hljs-punctuation { color: #9a8f7e; }
 
     /* Code block */
     .h-bubble pre {
@@ -2215,7 +2217,7 @@
       font-size: 13px;
       font-style: normal;
       line-height: 1.6;
-      color: oklch(0.875 0.010 55);
+      color: #d3c8b4;
       padding: 14px 16px;
       padding-right: 52px;
       overflow-x: auto;
@@ -2234,7 +2236,7 @@
       font-size: 10px;
       font-weight: 500;
       letter-spacing: 0.3px;
-      color: oklch(0.52 0.015 55);
+      color: #837868;
       text-transform: uppercase;
       pointer-events: none;
       line-height: 1;
@@ -2471,20 +2473,20 @@
     .s-docs-body .h-code-lang { color: var(--h-ink-faint); }
     .s-docs-body pre code { background: none; padding: 0; font-size: 13px; color: var(--h-ink); }
     .s-docs-body pre .hljs { color: var(--h-ink); }
-    .s-docs-body pre .hljs-keyword, .s-docs-body pre .hljs-selector-tag, .s-docs-body pre .hljs-built_in { color: oklch(0.48 0.16 280); }
-    .s-docs-body pre .hljs-string, .s-docs-body pre .hljs-attr, .s-docs-body pre .hljs-addition { color: oklch(0.45 0.14 150); }
-    .s-docs-body pre .hljs-number, .s-docs-body pre .hljs-literal { color: oklch(0.52 0.14 45); }
+    .s-docs-body pre .hljs-keyword, .s-docs-body pre .hljs-selector-tag, .s-docs-body pre .hljs-built_in { color: #8c5a42; }
+    .s-docs-body pre .hljs-string, .s-docs-body pre .hljs-attr, .s-docs-body pre .hljs-addition { color: #7a6832; }
+    .s-docs-body pre .hljs-number, .s-docs-body pre .hljs-literal { color: #8a5a6e; }
     .s-docs-body pre .hljs-comment, .s-docs-body pre .hljs-quote { color: var(--h-ink-faint); font-style: italic; }
-    .s-docs-body pre .hljs-function .hljs-title, .s-docs-body pre .hljs-title.function_, .s-docs-body pre .hljs-title.class_ { color: oklch(0.50 0.14 240); }
-    .s-docs-body pre .hljs-type, .s-docs-body pre .hljs-params { color: oklch(0.50 0.10 200); }
-    .s-docs-body pre .hljs-property, .s-docs-body pre .hljs-attribute { color: oklch(0.50 0.08 45); }
-    html.dark .s-docs-body pre .hljs-keyword, html.dark .s-docs-body pre .hljs-selector-tag, html.dark .s-docs-body pre .hljs-built_in { color: oklch(0.72 0.12 280); }
-    html.dark .s-docs-body pre .hljs-string, html.dark .s-docs-body pre .hljs-attr, html.dark .s-docs-body pre .hljs-addition { color: oklch(0.72 0.11 145); }
-    html.dark .s-docs-body pre .hljs-number, html.dark .s-docs-body pre .hljs-literal { color: oklch(0.75 0.10 45); }
+    .s-docs-body pre .hljs-function .hljs-title, .s-docs-body pre .hljs-title.function_, .s-docs-body pre .hljs-title.class_ { color: #4a7a68; }
+    .s-docs-body pre .hljs-type, .s-docs-body pre .hljs-params { color: #4a7a68; }
+    .s-docs-body pre .hljs-property, .s-docs-body pre .hljs-attribute { color: var(--h-ink-mute); }
+    html.dark .s-docs-body pre .hljs-keyword, html.dark .s-docs-body pre .hljs-selector-tag, html.dark .s-docs-body pre .hljs-built_in { color: #c2876b; }
+    html.dark .s-docs-body pre .hljs-string, html.dark .s-docs-body pre .hljs-attr, html.dark .s-docs-body pre .hljs-addition { color: #b59a5e; }
+    html.dark .s-docs-body pre .hljs-number, html.dark .s-docs-body pre .hljs-literal { color: #c08aa0; }
     html.dark .s-docs-body pre .hljs-comment, html.dark .s-docs-body pre .hljs-quote { color: var(--h-ink-faint); }
-    html.dark .s-docs-body pre .hljs-function .hljs-title, html.dark .s-docs-body pre .hljs-title.function_, html.dark .s-docs-body pre .hljs-title.class_ { color: oklch(0.75 0.10 240); }
-    html.dark .s-docs-body pre .hljs-type, html.dark .s-docs-body pre .hljs-params { color: oklch(0.72 0.08 200); }
-    html.dark .s-docs-body pre .hljs-property, html.dark .s-docs-body pre .hljs-attribute { color: oklch(0.78 0.06 45); }
+    html.dark .s-docs-body pre .hljs-function .hljs-title, html.dark .s-docs-body pre .hljs-title.function_, html.dark .s-docs-body pre .hljs-title.class_ { color: #6f9f8c; }
+    html.dark .s-docs-body pre .hljs-type, html.dark .s-docs-body pre .hljs-params { color: #6f9f8c; }
+    html.dark .s-docs-body pre .hljs-property, html.dark .s-docs-body pre .hljs-attribute { color: #d3c8b4; }
     .s-docs-body a { color: var(--h-ink-mute); text-underline-offset: 3px; }
     .s-docs-body hr { border: none; border-top: 1px solid var(--h-hair-soft); margin: 24px 0; }
     .s-docs-body strong { color: var(--h-ink); }

--- a/index.html
+++ b/index.html
@@ -5373,7 +5373,10 @@ function openFileFromPath(absOrRelPath) {
     if (ws && ws.readyState === 1) {
       ws.send(JSON.stringify(isAbsolute ? { type: 'file_list', abs_path: filePath } : { type: 'file_list' }));
     }
-    wsSetView('files');
+    wsActiveView = 'files';
+    wsActiveFile = null;
+    document.querySelectorAll('.ws-pin-tab').forEach(t => t.classList.toggle('active', t.dataset.wsPin === 'files'));
+    wsRenderContent();
   } else {
     if (isAbsolute && ws && ws.readyState === 1) {
       ws.send(JSON.stringify({ type: 'file_read', path: filePath, absolute: true }));

--- a/index.html
+++ b/index.html
@@ -3242,6 +3242,9 @@
     </div>
     <div class="h-empty-logo">the porch is quiet.</div>
     <div class="h-empty-sub">pick a room from the list on the left, or start a new one.</div>
+    <button class="h-rooms-toggle" id="empty-rooms-toggle" style="display:none;margin-top:12px" title="Show room list">
+      <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.5"/><path d="M9 4v16"/></svg>
+    </button>
   </div>
 
   <div id="settings-inner">
@@ -4626,6 +4629,8 @@ function applyTheme(dark) {
 function toggleSidebar() {
   const collapsed = document.body.classList.toggle('sidebar-collapsed');
   localStorage.setItem('stoa-sidebar-collapsed', collapsed ? '1' : '');
+  const emptyBtn = document.getElementById('empty-rooms-toggle');
+  if (emptyBtn) emptyBtn.style.display = collapsed ? '' : 'none';
   if (currentRoomId) {
     const parts = roomParticipantsCache[currentRoomId] || [];
     const room = { id: currentRoomId, title: document.querySelector('.h-room-name')?.textContent || '' };
@@ -6653,8 +6658,11 @@ async function init() {
   // Restore sidebar collapsed state
   if (localStorage.getItem('stoa-sidebar-collapsed') === '1') {
     document.body.classList.add('sidebar-collapsed');
+    const emptyBtn = document.getElementById('empty-rooms-toggle');
+    if (emptyBtn) emptyBtn.style.display = '';
   }
   document.getElementById('sidebar-collapse-btn').onclick = toggleSidebar;
+  document.getElementById('empty-rooms-toggle').onclick = toggleSidebar;
   // Auth check — show login if not authenticated
   const isAuthed = await checkAuth();
   if (!isAuthed) { showLogin(); return; }

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600&family=Plus+Jakarta+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
   <script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -2055,6 +2056,23 @@
       color: oklch(0.150 0.010 45);
     }
 
+    /* ── Syntax highlighting (warm Stoa palette) ── */
+    .hljs { background: transparent; color: oklch(0.875 0.010 55); }
+    .hljs-keyword, .hljs-selector-tag, .hljs-built_in, .hljs-deletion { color: oklch(0.72 0.12 25); }
+    .hljs-string, .hljs-attr, .hljs-addition { color: oklch(0.72 0.11 145); }
+    .hljs-number, .hljs-literal, .hljs-variable.constant_ { color: oklch(0.75 0.10 70); }
+    .hljs-comment, .hljs-quote { color: oklch(0.52 0.015 55); font-style: italic; }
+    .hljs-function .hljs-title, .hljs-title.function_, .hljs-title.class_ { color: oklch(0.78 0.10 220); }
+    .hljs-type, .hljs-params { color: oklch(0.75 0.08 200); }
+    .hljs-property, .hljs-attribute { color: oklch(0.78 0.06 70); }
+    .hljs-regexp, .hljs-link { color: oklch(0.70 0.12 35); }
+    .hljs-meta, .hljs-tag { color: oklch(0.65 0.06 55); }
+    .hljs-name, .hljs-selector-class, .hljs-selector-id { color: oklch(0.72 0.10 25); }
+    .hljs-symbol, .hljs-bullet { color: oklch(0.72 0.11 145); }
+    .hljs-template-variable, .hljs-subst { color: oklch(0.80 0.08 50); }
+    .hljs-emphasis { font-style: italic; }
+    .hljs-strong { font-weight: 600; }
+
     /* Code block */
     .h-bubble pre {
       position: relative;
@@ -2081,6 +2099,24 @@
       overflow-wrap: break-word;
       word-break: normal;
       background: transparent;
+    }
+
+    /* Language label */
+    .h-code-lang {
+      position: absolute;
+      top: 8px;
+      left: 12px;
+      font-family: var(--h-sans);
+      font-size: 10px;
+      font-weight: 500;
+      letter-spacing: 0.3px;
+      color: oklch(0.52 0.015 55);
+      text-transform: uppercase;
+      pointer-events: none;
+      line-height: 1;
+    }
+    .h-bubble pre:has(.h-code-lang) code {
+      padding-top: 28px;
     }
 
     /* Copy button */
@@ -2307,7 +2343,24 @@
     .s-docs-body ul, .s-docs-body ol { padding-left: 20px; margin-bottom: 12px; }
     .s-docs-body code { font-size: 12.5px; background: var(--h-hairline); padding: 1px 5px; border-radius: 4px; }
     .s-docs-body pre { background: color-mix(in srgb, var(--h-ink) 6%, var(--h-surface)); border: 1px solid var(--h-hairline); border-radius: 8px; padding: 14px 16px; overflow-x: auto; margin-bottom: 16px; position: relative; }
-    .s-docs-body pre code { background: none; padding: 0; font-size: 13px; }
+    .s-docs-body pre:has(.h-code-lang) code { padding-top: 14px; }
+    .s-docs-body .h-code-lang { color: var(--h-ink-faint); }
+    .s-docs-body pre code { background: none; padding: 0; font-size: 13px; color: var(--h-ink); }
+    .s-docs-body pre .hljs { color: var(--h-ink); }
+    .s-docs-body pre .hljs-keyword, .s-docs-body pre .hljs-selector-tag, .s-docs-body pre .hljs-built_in { color: oklch(0.48 0.16 280); }
+    .s-docs-body pre .hljs-string, .s-docs-body pre .hljs-attr, .s-docs-body pre .hljs-addition { color: oklch(0.45 0.14 150); }
+    .s-docs-body pre .hljs-number, .s-docs-body pre .hljs-literal { color: oklch(0.52 0.14 45); }
+    .s-docs-body pre .hljs-comment, .s-docs-body pre .hljs-quote { color: var(--h-ink-faint); font-style: italic; }
+    .s-docs-body pre .hljs-function .hljs-title, .s-docs-body pre .hljs-title.function_, .s-docs-body pre .hljs-title.class_ { color: oklch(0.50 0.14 240); }
+    .s-docs-body pre .hljs-type, .s-docs-body pre .hljs-params { color: oklch(0.50 0.10 200); }
+    .s-docs-body pre .hljs-property, .s-docs-body pre .hljs-attribute { color: oklch(0.50 0.08 45); }
+    html.dark .s-docs-body pre .hljs-keyword, html.dark .s-docs-body pre .hljs-selector-tag, html.dark .s-docs-body pre .hljs-built_in { color: oklch(0.72 0.12 280); }
+    html.dark .s-docs-body pre .hljs-string, html.dark .s-docs-body pre .hljs-attr, html.dark .s-docs-body pre .hljs-addition { color: oklch(0.72 0.11 145); }
+    html.dark .s-docs-body pre .hljs-number, html.dark .s-docs-body pre .hljs-literal { color: oklch(0.75 0.10 45); }
+    html.dark .s-docs-body pre .hljs-comment, html.dark .s-docs-body pre .hljs-quote { color: var(--h-ink-faint); }
+    html.dark .s-docs-body pre .hljs-function .hljs-title, html.dark .s-docs-body pre .hljs-title.function_, html.dark .s-docs-body pre .hljs-title.class_ { color: oklch(0.75 0.10 240); }
+    html.dark .s-docs-body pre .hljs-type, html.dark .s-docs-body pre .hljs-params { color: oklch(0.72 0.08 200); }
+    html.dark .s-docs-body pre .hljs-property, html.dark .s-docs-body pre .hljs-attribute { color: oklch(0.78 0.06 45); }
     .s-docs-body a { color: var(--h-ink-mute); text-underline-offset: 3px; }
     .s-docs-body hr { border: none; border-top: 1px solid var(--h-hair-soft); margin: 24px 0; }
     .s-docs-body strong { color: var(--h-ink); }
@@ -3922,11 +3975,28 @@ function toggleTheme() {
 }
 
 // ── Markdown rendering ─────────────────────────────────────────────────────
-marked.setOptions({ breaks: true, gfm: true });
+marked.use({
+  breaks: true, gfm: true,
+  renderer: {
+    code({ text, lang }) {
+      let highlighted;
+      const language = lang && hljs.getLanguage(lang) ? lang : null;
+      try {
+        highlighted = language
+          ? hljs.highlight(text, { language }).value
+          : hljs.highlightAuto(text).value;
+      } catch { highlighted = text; }
+      const langLabel = language
+        ? `<span class="h-code-lang">${language}</span>`
+        : '';
+      return `<pre>${langLabel}<code class="hljs${language ? ' language-' + language : ''}">${highlighted}</code></pre>`;
+    }
+  }
+});
 
 function renderMarkdown(text) {
   if (!text) return '';
-  return DOMPurify.sanitize(marked.parse(text));
+  return DOMPurify.sanitize(marked.parse(text), { ADD_ATTR: ['class'] });
 }
 
 async function copyToClipboard(text) {
@@ -6773,7 +6843,7 @@ async function sOpenDoc(slug) {
     const res = await fetch(`/api/docs/${encodeURIComponent(filename)}`);
     if (!res.ok) { body.innerHTML = '<p class="s-docs-empty">document not found.</p>'; return; }
     const md = await res.text();
-    body.innerHTML = DOMPurify.sanitize(marked.parse(md));
+    body.innerHTML = DOMPurify.sanitize(marked.parse(md), { ADD_ATTR: ['class'] });
     addCopyButtons(body);
     if (lang !== docsLang) {
       const note = document.createElement('p');

--- a/index.html
+++ b/index.html
@@ -4613,10 +4613,23 @@ function handleWsMessage(msg) {
     return;
   }
 
-  if (msg.type === 'file_read' && !msg.error) {
+  if (msg.type === 'file_read') {
+    if (msg.error) { console.warn('[ws] file_read error:', msg.error); return; }
     const panel = document.getElementById('workspace-panel');
     if (!panel.classList.contains('open')) toggleWorkspacePanel();
-    wsOpenFile(msg.path, msg.content);
+    if (msg.base64) {
+      const ext = wsGetExt(msg.path);
+      const mimeMap = { png:'image/png', jpg:'image/jpeg', jpeg:'image/jpeg', gif:'image/gif', webp:'image/webp', svg:'image/svg+xml', ico:'image/x-icon', bmp:'image/bmp' };
+      const existing = wsOpenFiles.find(f => f.name === msg.path);
+      if (existing) existing.base64 = msg.base64;
+      else wsOpenFiles.push({ name: msg.path, content: '', base64: msg.base64, ext });
+      wsActiveFile = msg.path;
+      wsActiveView = 'file';
+      wsRenderTabs();
+      wsRenderContent();
+    } else {
+      wsOpenFile(msg.path, msg.content);
+    }
     return;
   }
 
@@ -4734,8 +4747,13 @@ function wsOpenFile(name, content) {
     wsOpenFiles.push({ name, content: content || '', ext: wsGetExt(name) });
   }
   const imgExts = new Set(['png','jpg','jpeg','gif','webp','svg','ico','bmp']);
-  if (!content && !imgExts.has(wsGetExt(name)) && ws) {
-    ws.send(JSON.stringify({ type: 'file_read', path: name }));
+  const fileExt = wsGetExt(name);
+  if (!content && ws) {
+    if (imgExts.has(fileExt)) {
+      ws.send(JSON.stringify({ type: 'file_read', path: name, binary: true }));
+    } else {
+      ws.send(JSON.stringify({ type: 'file_read', path: name }));
+    }
   }
   wsActiveFile = name;
   wsActiveView = 'file';
@@ -4924,7 +4942,15 @@ function wsRenderContent() {
       content.className = 'ws-scroll';
       content.style.cssText = 'flex:1;min-height:0;overflow:auto;display:flex;align-items:center;justify-content:center;padding:24px;background:color-mix(in srgb,var(--h-ink) 4%,var(--h-bg))';
       const img = document.createElement('img');
-      img.src = `/api/workspace/file?room=${currentRoomId}&path=${encodeURIComponent(file.name)}`;
+      const mimeMap = { png:'image/png', jpg:'image/jpeg', jpeg:'image/jpeg', gif:'image/gif', webp:'image/webp', svg:'image/svg+xml', ico:'image/x-icon', bmp:'image/bmp' };
+      if (file.base64) {
+        img.src = `data:${mimeMap[ext] || 'image/png'};base64,${file.base64}`;
+      } else {
+        img.src = `/api/workspace/file?room=${currentRoomId}&path=${encodeURIComponent(file.name)}`;
+        img.onerror = () => {
+          if (ws && ws.readyState === 1) ws.send(JSON.stringify({ type: 'file_read', path: file.name, binary: true }));
+        };
+      }
       img.style.cssText = 'max-width:100%;max-height:100%;object-fit:contain;border-radius:8px;box-shadow:0 2px 12px rgba(0,0,0,.12)';
       img.alt = file.name;
       content.appendChild(img);

--- a/index.html
+++ b/index.html
@@ -4343,7 +4343,8 @@ document.addEventListener('click', e => {
 
 async function archiveRoom(room) {
   try {
-    await fetch(`/api/rooms/${room.id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ archived: true }) });
+    const res = await fetch(`/api/rooms/${room.id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ archived: true }) });
+    if (!res.ok) throw new Error('archive failed');
   } catch { showToast('Failed to archive room', { error: true }); return; }
   if (currentRoomId === room.id) {
     currentRoomId = null;
@@ -4355,7 +4356,8 @@ async function archiveRoom(room) {
 
 async function restoreRoom(room) {
   try {
-    await fetch(`/api/rooms/${room.id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ archived: false }) });
+    const res = await fetch(`/api/rooms/${room.id}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ archived: false }) });
+    if (!res.ok) throw new Error('restore failed');
   } catch { showToast('Failed to restore room', { error: true }); return; }
   refreshRoomList();
 }

--- a/index.html
+++ b/index.html
@@ -5450,9 +5450,6 @@ function appendToken(msgId, token) {
       // Copy colors from thinking bubble
       bubble.style.background = thinkBubble.style.background;
       bubble.style.borderColor  = thinkBubble.style.borderColor;
-      bubble.style.fontFamily = 'var(--h-msg)';
-      bubble.style.fontSize = '15px';
-      bubble.style.lineHeight = '1.7';
       bubble.style.letterSpacing = '';
       bubble.style.borderTopLeftRadius = '4px';
       body.replaceChild(bubble, thinkBubble);
@@ -5500,9 +5497,9 @@ function finalizeMessage(msgId, content, fileUrl, fileName, attachments) {
       bubble.classList.remove('h-thinking-bubble');
       bubble.classList.add('h-bubble');
       bubble.style.color = '';
-      bubble.style.fontFamily = 'var(--h-msg)';
-      bubble.style.fontSize = '15px';
-      bubble.style.lineHeight = '1.7';
+      bubble.style.fontFamily = '';
+      bubble.style.fontSize = '';
+      bubble.style.lineHeight = '';
       bubble.style.borderTopLeftRadius = '4px';
     }
 

--- a/index.html
+++ b/index.html
@@ -78,11 +78,49 @@
     }
 
     .h-sidebar-head {
-      padding: 0 4px 18px;
+      padding: 0 4px 16px;
       display: flex;
       align-items: center;
       justify-content: space-between;
+      gap: 8px;
     }
+
+    .h-sidebar-collapse {
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      width: 28px;
+      height: 28px;
+      border-radius: 8px;
+      padding: 0;
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--h-ink-mute);
+      transition: color .12s, background .12s;
+    }
+    .h-sidebar-collapse:hover { color: var(--h-ink); background: var(--h-surface-hi); }
+
+    .h-rooms-toggle {
+      width: 34px;
+      height: 34px;
+      border-radius: 9px;
+      cursor: pointer;
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid var(--h-hair-soft);
+      background: transparent;
+      color: var(--h-ink-mute);
+      margin-right: 4px;
+      transition: color .12s, background .12s;
+    }
+    .h-rooms-toggle:hover { color: var(--h-ink); background: var(--h-surface-hi); }
+
+    body.sidebar-collapsed #sidebar { display: none; }
+
     #refresh-btn {
       display: none;
       background: none;
@@ -1109,16 +1147,16 @@
     }
     .h-msg-row.ai .h-bubble {
       font-family: var(--h-msg);
-      font-size: calc(var(--stoa-msg-scale, 1) * 15px);
+      font-size: calc(var(--stoa-msg-scale, 1) * 19px);
       font-weight: 400;
-      line-height: calc(1.7 * var(--stoa-msg-leading, 1));
+      line-height: calc(1.5 * var(--stoa-msg-leading, 1));
       border-top-left-radius: 4px;
     }
     .h-msg-row.human .h-bubble {
       font-family: var(--h-msg);
-      font-size: calc(var(--stoa-msg-scale, 1) * 15px);
+      font-size: calc(var(--stoa-msg-scale, 1) * 16px);
       font-weight: 400;
-      line-height: calc(1.65 * var(--stoa-msg-leading, 1));
+      line-height: calc(1.55 * var(--stoa-msg-leading, 1));
       border-top-right-radius: 4px;
     }
 
@@ -1838,25 +1876,30 @@
     .h-msg-actions {
       display: none;
       position: absolute;
-      top: 26px;
-      gap: 2px;
-      padding: 2px;
+      top: -15px;
+      gap: 1px;
+      padding: 3px;
+      border-radius: 9px;
+      background: var(--h-surface);
+      border: 1px solid var(--h-hairline);
+      box-shadow: 0 2px 10px rgba(0,0,0,.14);
       z-index: 5;
     }
     .h-msg-row:hover .h-msg-actions, .h-msg-row.show-actions .h-msg-actions { display: flex; }
-    .h-msg-row.ai .h-msg-actions { left: calc(100% + 6px); }
-    .h-msg-row.human .h-msg-actions { right: calc(100% + 6px); }
+    .h-msg-row.ai .h-msg-actions { right: 8px; }
+    .h-msg-row.human .h-msg-actions { left: 8px; }
     .h-msg-action-btn {
       border: none;
       background: none;
-      color: var(--h-ink-faint);
+      color: var(--h-ink-mute);
       cursor: pointer;
-      padding: 4px 6px;
-      border-radius: 4px;
+      padding: 5px;
+      border-radius: 6px;
       display: flex;
       align-items: center;
+      transition: background .12s, color .12s;
     }
-    .h-msg-action-btn:hover { background: var(--h-hair-soft); color: var(--h-ink); }
+    .h-msg-action-btn:hover { background: var(--h-surface-hi); color: var(--h-ink); }
 
     .h-msg-action-btn.copied svg { stroke: #5cb85c; }
     .h-msg-action-btn.copied { background: rgba(92,184,92,.12); }
@@ -3081,6 +3124,9 @@
     <button id="refresh-btn" title="Reload" aria-label="Reload" onclick="location.reload(true)">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
     </button>
+    <button class="h-sidebar-collapse" id="sidebar-collapse-btn" title="Hide room list">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M13 7l-4 5 4 5"/><path d="M18 7l-4 5 4 5"/></svg>
+    </button>
   </div>
   <div class="h-search-wrap">
     <svg class="h-search-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
@@ -3779,6 +3825,15 @@ function renderChatHeader(room, participants) {
   backBtn.innerHTML = '&#8592;';
   backBtn.onclick = () => document.body.classList.remove('in-chat');
   header.appendChild(backBtn);
+
+  if (document.body.classList.contains('sidebar-collapsed')) {
+    const roomsToggle = document.createElement('button');
+    roomsToggle.className = 'h-rooms-toggle';
+    roomsToggle.title = 'Show room list';
+    roomsToggle.innerHTML = `<svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2.5"/><path d="M9 4v16"/></svg>`;
+    roomsToggle.onclick = () => toggleSidebar();
+    header.appendChild(roomsToggle);
+  }
 
   const info = document.createElement('div');
   info.className = 'h-header-info';
@@ -4491,6 +4546,16 @@ function applyTheme(dark) {
   localStorage.setItem('stoa-theme', dark ? 'dark' : 'light');
   const btn = document.getElementById('theme-toggle');
   if (btn) { btn.innerHTML = dark ? SUN_SVG : MOON_SVG; btn.title = dark ? 'switch to light' : 'switch to dark'; }
+}
+
+function toggleSidebar() {
+  const collapsed = document.body.classList.toggle('sidebar-collapsed');
+  localStorage.setItem('stoa-sidebar-collapsed', collapsed ? '1' : '');
+  if (currentRoomId) {
+    const parts = roomParticipantsCache[currentRoomId] || [];
+    const room = { id: currentRoomId, title: document.querySelector('.h-room-name')?.textContent || '' };
+    renderChatHeader(room, parts);
+  }
 }
 
 function toggleTheme() {
@@ -6509,6 +6574,11 @@ async function init() {
       document.documentElement.style.setProperty(cssVar, k === 'width' ? v + 'px' : v);
     }
   });
+  // Restore sidebar collapsed state
+  if (localStorage.getItem('stoa-sidebar-collapsed') === '1') {
+    document.body.classList.add('sidebar-collapsed');
+  }
+  document.getElementById('sidebar-collapse-btn').onclick = toggleSidebar;
   // Auth check — show login if not authenticated
   const isAuthed = await checkAuth();
   if (!isAuthed) { showLogin(); return; }

--- a/index.html
+++ b/index.html
@@ -1221,16 +1221,16 @@
     }
     .h-msg-row.ai .h-bubble {
       font-family: var(--h-msg);
-      font-size: calc(var(--stoa-msg-scale, 1) * 19px);
+      font-size: calc(var(--stoa-msg-scale, 1) * 16px);
       font-weight: 400;
-      line-height: calc(1.5 * var(--stoa-msg-leading, 1));
+      line-height: calc(1.6 * var(--stoa-msg-leading, 1));
       border-top-left-radius: 4px;
     }
     .h-msg-row.human .h-bubble {
       font-family: var(--h-msg);
       font-size: calc(var(--stoa-msg-scale, 1) * 16px);
       font-weight: 400;
-      line-height: calc(1.55 * var(--stoa-msg-leading, 1));
+      line-height: calc(1.6 * var(--stoa-msg-leading, 1));
       border-top-right-radius: 4px;
     }
 

--- a/index.html
+++ b/index.html
@@ -4612,6 +4612,7 @@ function handleWsMessage(msg) {
     if (msg.error) { console.warn('[ws] file_list error:', msg.error); return; }
     wsFileTreeData = msg.tree || [];
     wsFileTreeRoot = msg.root || '';
+    wsModifiedFiles = new Set(msg.modified || []);
     if (wsActiveView === 'files') wsRenderContent();
     return;
   }
@@ -4718,6 +4719,7 @@ let wsActiveFile = null;
 let wsFileTreeData = [];
 let wsFileTreeRoot = '';
 let wsGitDiffData = [];
+let wsModifiedFiles = new Set();
 
 function toggleWorkspacePanel() {
   const panel = document.getElementById('workspace-panel');
@@ -4810,6 +4812,13 @@ function wsRenderFileTree(container, nodes, parentPath) {
       row.appendChild(nameEl);
 
       const relPath = parentPath ? parentPath + '/' + node.name : node.name;
+      if (wsModifiedFiles.has(relPath) || wsModifiedFiles.has(node.name)) {
+        const dot = document.createElement('span');
+        dot.className = 'ws-tree-modified';
+        dot.title = 'modified';
+        dot.style.background = '#d39749';
+        row.appendChild(dot);
+      }
       const fullPath = wsFileTreeRoot ? wsFileTreeRoot.replace(/\\/g, '/').replace(/\/+$/, '') + '/' + relPath : relPath;
       row.onclick = () => {
         const panel = document.getElementById('workspace-panel');
@@ -4967,7 +4976,7 @@ function wsRenderContent() {
       addCopyButtons(inner);
       content.appendChild(inner);
     } else if (file.loaded) {
-      wsRenderCodeViewer(content, file.content || '');
+      wsRenderCodeViewer(content, file.content || '', file.name);
     } else {
       content.innerHTML = `<div class="ws-empty-state">
         <div class="ws-empty-title">loading…</div>
@@ -4977,11 +4986,19 @@ function wsRenderContent() {
   }
 }
 
-function wsRenderCodeViewer(container, text) {
+function wsRenderCodeViewer(container, text, fileName) {
   const lines = text.split('\n');
   const gutW = String(lines.length).length * 9 + 22;
   container.className = 'ws-code ws-mono ws-code-viewer';
   container.style.cssText = '';
+  const ext = fileName ? wsGetExt(fileName) : '';
+  const langMap = { js:'javascript', jsx:'javascript', ts:'typescript', tsx:'typescript', py:'python', json:'json', html:'xml', css:'css', sql:'sql', sh:'bash', yml:'yaml', yaml:'yaml', xml:'xml', rb:'ruby', go:'go', rs:'rust', java:'java', c:'c', cpp:'cpp', ps1:'powershell' };
+  const lang = langMap[ext] || null;
+  let hlLines = null;
+  try {
+    const hlText = lang ? hljs.highlight(text, { language: lang }).value : hljs.highlightAuto(text).value;
+    hlLines = hlText.split('\n');
+  } catch {}
   const table = document.createElement('div');
   table.className = 'ws-code-table';
   lines.forEach((ln, i) => {
@@ -4994,7 +5011,7 @@ function wsRenderCodeViewer(container, text) {
     row.appendChild(gutter);
     const code = document.createElement('span');
     code.className = 'ws-code-text';
-    code.textContent = ln || ' ';
+    if (hlLines && hlLines[i] != null) { code.innerHTML = hlLines[i] || "&nbsp;"; } else { code.textContent = ln || " "; }
     row.appendChild(code);
     table.appendChild(row);
   });

--- a/index.html
+++ b/index.html
@@ -858,7 +858,7 @@
       flex: 1;
       min-height: 0;
       overflow: auto;
-      font-size: 13px;
+      font-size: calc(var(--stoa-msg-scale, 1) * 13px);
       line-height: 21px;
     }
     .ws-code-table { display: table; min-width: 100%; }
@@ -910,28 +910,28 @@
     /* ── Markdown viewer ──────────────────────────── */
     .ws-md-body { max-width: 620px; }
     .ws-md-body h1 {
-      font-family: var(--h-serif); font-size: 30px; font-weight: 400;
+      font-family: var(--h-serif); font-size: calc(var(--stoa-msg-scale, 1) * 26px); font-weight: 400;
       color: var(--h-ink); margin: 0 0 12px; line-height: 1.15;
       padding-bottom: 10px; border-bottom: 1px solid var(--h-hair-soft);
     }
     .ws-md-body h2 {
-      font-family: var(--h-serif); font-size: 21px; font-weight: 400;
+      font-family: var(--h-serif); font-size: calc(var(--stoa-msg-scale, 1) * 20px); font-weight: 400;
       color: var(--h-ink); margin: 28px 0 10px; line-height: 1.2;
     }
     .ws-md-body h3 {
-      font-family: var(--h-serif); font-size: 17px; font-weight: 500;
+      font-family: var(--h-serif); font-size: calc(var(--stoa-msg-scale, 1) * 16px); font-weight: 500;
       color: var(--h-ink); margin: 22px 0 8px;
     }
     .ws-md-body h4, .ws-md-body h5, .ws-md-body h6 {
-      font-family: var(--h-serif); font-size: 15px; font-weight: 500;
+      font-family: var(--h-serif); font-size: calc(var(--stoa-msg-scale, 1) * 14px); font-weight: 500;
       color: var(--h-ink-mute); margin: 18px 0 6px;
     }
     .ws-md-body p {
-      font-family: var(--h-sans); font-size: 15px; line-height: 1.65;
+      font-family: var(--h-sans); font-size: calc(var(--stoa-msg-scale, 1) * 15px); line-height: 1.65;
       color: var(--h-ink); margin: 0 0 16px; text-wrap: pretty;
     }
     .ws-md-body ul, .ws-md-body ol {
-      font-family: var(--h-sans); font-size: 15px; line-height: 1.65;
+      font-family: var(--h-sans); font-size: calc(var(--stoa-msg-scale, 1) * 15px); line-height: 1.65;
       color: var(--h-ink); padding-left: 22px; margin: 0 0 16px;
     }
     .ws-md-body li { margin-bottom: 4px; }
@@ -963,13 +963,13 @@
     .ws-md-body pre code {
       display: block; padding: 14px 16px; padding-right: 52px;
       font-family: "Cascadia Code", "Fira Code", Consolas, monospace;
-      font-size: 13px; line-height: 1.6; color: #d3c8b4;
+      font-size: calc(var(--stoa-msg-scale, 1) * 13px); line-height: 1.6; color: #d3c8b4;
       white-space: pre-wrap; overflow-wrap: break-word;
       background: transparent;
     }
     .ws-md-body table {
       border-collapse: collapse; margin: 0 0 16px;
-      font-family: var(--h-sans); font-size: 14px; width: auto;
+      font-family: var(--h-sans); font-size: calc(var(--stoa-msg-scale, 1) * 14px); width: auto;
     }
     .ws-md-body th, .ws-md-body td {
       border: 1px solid var(--h-hair-soft); padding: 6px 12px; text-align: left;
@@ -2696,7 +2696,7 @@
     .h-bubble pre code {
       display: block;
       font-family: "Cascadia Code", "Fira Code", Consolas, monospace;
-      font-size: 13px;
+      font-size: calc(var(--stoa-msg-scale, 1) * 13px);
       font-style: normal;
       line-height: 1.6;
       color: #d3c8b4;
@@ -8153,10 +8153,10 @@ async function sOpenDoc(slug) {
 
 // ── Reading comfort controls ──────────────────────────────────────────────
 const MSG_SIZES = [
+  { label: 'Tiny', v: 0.72, icon: 13 },
+  { label: 'Small', v: 0.82, icon: 15 },
   { label: 'Compact', v: 0.9, icon: 17 },
-  { label: 'Cozy', v: 1.0, icon: 20 },
-  { label: 'Comfortable', v: 1.15, icon: 23 },
-  { label: 'Large', v: 1.3, icon: 26 },
+  { label: 'Default', v: 1.0, icon: 20 },
 ];
 const MSG_LEADS = [
   { label: 'Tight', v: 0.9, gap: 2 },
@@ -8266,7 +8266,7 @@ function sRenderReadingControls() {
     aiRow.className = 's-msg-preview-row';
     const aiBubble = document.createElement('div');
     aiBubble.className = 's-msg-preview-bubble';
-    aiBubble.style.cssText = `max-width:min(var(--stoa-msg-width,560px),78%);font-size:calc(var(--stoa-msg-scale,1)*15px);line-height:calc(1.7*var(--stoa-msg-leading,1));border-top-left-radius:4px;background:color-mix(in srgb,#6f9f8c 16%,var(--h-surface));border-color:color-mix(in srgb,#6f9f8c 36%,var(--h-surface))`;
+    aiBubble.style.cssText = `max-width:min(var(--stoa-msg-width,560px),78%);font-size:calc(var(--stoa-msg-scale,1)*16px);line-height:calc(1.6*var(--stoa-msg-leading,1));border-top-left-radius:4px;background:color-mix(in srgb,#6f9f8c 16%,var(--h-surface));border-color:color-mix(in srgb,#6f9f8c 36%,var(--h-surface))`;
     aiBubble.innerHTML = 'The client replays from the last <em>message_state</em> event — not from the last token, so a reconnect never loses the thread.';
     aiRow.appendChild(aiBubble);
     preview.appendChild(aiRow);
@@ -8275,7 +8275,7 @@ function sRenderReadingControls() {
     humanRow.className = 's-msg-preview-row human';
     const humanBubble = document.createElement('div');
     humanBubble.className = 's-msg-preview-bubble';
-    humanBubble.style.cssText = `max-width:min(var(--stoa-msg-width,560px),78%);font-size:calc(var(--stoa-msg-scale,1)*15px);line-height:calc(1.55*var(--stoa-msg-leading,1));border-top-right-radius:4px;background:var(--h-slip);border-color:var(--h-hair-soft)`;
+    humanBubble.style.cssText = `max-width:min(var(--stoa-msg-width,560px),78%);font-size:calc(var(--stoa-msg-scale,1)*16px);line-height:calc(1.6*var(--stoa-msg-leading,1));border-top-right-radius:4px;background:var(--h-slip);border-color:var(--h-hair-soft)`;
     humanBubble.textContent = 'Got it — that reads much better at this size.';
     humanRow.appendChild(humanBubble);
     preview.appendChild(humanRow);

--- a/index.html
+++ b/index.html
@@ -4605,7 +4605,8 @@ function handleWsMessage(msg) {
     return;
   }
 
-  if (msg.type === 'file_list' && !msg.error) {
+  if (msg.type === 'file_list') {
+    if (msg.error) { console.warn('[ws] file_list error:', msg.error); return; }
     wsFileTreeData = msg.tree || [];
     wsFileTreeRoot = msg.root || '';
     if (wsActiveView === 'files') wsRenderContent();
@@ -5370,8 +5371,8 @@ function openFileFromPath(absOrRelPath) {
   if (!panel.classList.contains('open')) toggleWorkspacePanel();
   const ext = wsGetExt(relPath);
   if (!ext) {
+    if (ws) ws.send(JSON.stringify({ type: 'file_list' }));
     wsSetView('files');
-    showToast('Directory path — showing file tree');
   } else {
     wsOpenFile(relPath);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/schema.sqlite.sql
+++ b/schema.sqlite.sql
@@ -140,6 +140,8 @@ CREATE INDEX IF NOT EXISTS idx_messages_participant_id ON messages(participant_i
 CREATE INDEX IF NOT EXISTS idx_ai_sessions_participant_id ON ai_sessions(participant_id);
 CREATE INDEX IF NOT EXISTS idx_messages_reply_to ON messages(reply_to);
 CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires ON auth_sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_rooms_workdir_id ON rooms(workdir_id);
+CREATE INDEX IF NOT EXISTS idx_rooms_created_by ON rooms(created_by);
 
 CREATE TABLE IF NOT EXISTS auth_users (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/schema.sqlite.sql
+++ b/schema.sqlite.sql
@@ -139,7 +139,6 @@ CREATE INDEX IF NOT EXISTS idx_agent_skills_workdir_id ON agent_skills(workdir_i
 CREATE INDEX IF NOT EXISTS idx_messages_participant_id ON messages(participant_id);
 CREATE INDEX IF NOT EXISTS idx_ai_sessions_participant_id ON ai_sessions(participant_id);
 CREATE INDEX IF NOT EXISTS idx_messages_reply_to ON messages(reply_to);
-CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires ON auth_sessions(expires_at);
 CREATE INDEX IF NOT EXISTS idx_rooms_workdir_id ON rooms(workdir_id);
 CREATE INDEX IF NOT EXISTS idx_rooms_created_by ON rooms(created_by);
 
@@ -158,6 +157,8 @@ CREATE TABLE IF NOT EXISTS auth_sessions (
   created_at TEXT DEFAULT (datetime('now')),
   FOREIGN KEY (user_id) REFERENCES auth_users(id) ON DELETE CASCADE
 );
+
+CREATE INDEX IF NOT EXISTS idx_auth_sessions_expires ON auth_sessions(expires_at);
 
 INSERT OR IGNORE INTO settings (scope, key_name, value) VALUES
   ('global','idle_timeout_seconds','300'),

--- a/server.js
+++ b/server.js
@@ -1619,18 +1619,16 @@ wss.on('connection', (ws, req) => {
       if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'file_list', error: 'no workdir' })); return; }
       const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_list', error: 'workdir not found' })); return; }
-      const localExists = fs.existsSync(wd.path);
-      if (localExists) {
-        const tree = buildFileTree(wd.path, wd.path, 0, 3);
-        ws.send(JSON.stringify({ type: 'file_list', root: wd.path, tree }));
+      const targetPath = msg.abs_path || wd.path;
+      if (fs.existsSync(targetPath)) {
+        const tree = buildFileTree(targetPath, targetPath, 0, 3);
+        ws.send(JSON.stringify({ type: 'file_list', root: targetPath, tree }));
       } else {
         const agentWs = agentClients.get(wd.actor_id);
-        console.log('[ws-file] agent ws for actor', wd.actor_id, ':', agentWs ? 'found' : 'NOT FOUND');
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
           pendingFileOps.set(rid, { type: 'file_list', clientWs: ws });
-          agentWs.send(JSON.stringify({ type: 'proxy_file_list', request_id: rid, workdir: wd.path }));
-          console.log('[ws-file] proxy_file_list sent to agent, rid:', rid);
+          agentWs.send(JSON.stringify({ type: 'proxy_file_list', request_id: rid, workdir: targetPath }));
         } else { ws.send(JSON.stringify({ type: 'file_list', error: 'agent offline' })); }
       }
     }
@@ -1640,7 +1638,8 @@ wss.on('connection', (ws, req) => {
       if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'file_read', error: 'no workdir' })); return; }
       const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_read', error: 'workdir not found' })); return; }
-      const filePath = path.resolve(wd.path, msg.path);
+      const resolveBase = msg.absolute ? '/' : wd.path;
+      const filePath = msg.absolute ? msg.path : path.resolve(wd.path, msg.path);
       if (fs.existsSync(filePath)) {
         try {
           const content = fs.readFileSync(filePath, 'utf8');
@@ -1651,7 +1650,9 @@ wss.on('connection', (ws, req) => {
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
           pendingFileOps.set(rid, { type: 'file_read', clientWs: ws });
-          agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: wd.path, path: msg.path }));
+          const proxyWorkdir = msg.absolute ? path.dirname(msg.path) : wd.path;
+          const proxyPath = msg.absolute ? path.basename(msg.path) : msg.path;
+          agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: proxyWorkdir, path: proxyPath }));
         } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
       }
     }

--- a/server.js
+++ b/server.js
@@ -912,14 +912,14 @@ const server = http.createServer(async (req, res) => {
   }
 
   // ── Workspace file serve (images, binary files) ──
-  if (req.method === 'GET' && url.pathname.startsWith('/api/workspace/file/')) {
+  if (req.method === 'GET' && url.pathname === '/api/workspace/file') {
     const roomId = url.searchParams.get('room');
-    if (!roomId) { res.writeHead(400); return res.end('missing room'); }
+    const relPath = url.searchParams.get('path');
+    if (!roomId || !relPath) { res.writeHead(400); return res.end('missing room or path'); }
     const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(roomId);
     if (!roomRow?.workdir_id) { res.writeHead(404); return res.end('no workdir'); }
     const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
     if (!wd?.path) { res.writeHead(404); return res.end('workdir not found'); }
-    const relPath = decodeURIComponent(url.pathname.slice('/api/workspace/file/'.length));
     const filePath = path.resolve(wd.path, relPath);
     if (!filePath.startsWith(path.resolve(wd.path))) { res.writeHead(403); return res.end('path traversal blocked'); }
     if (!fs.existsSync(filePath)) { res.writeHead(404); return res.end('not found'); }

--- a/server.js
+++ b/server.js
@@ -1644,7 +1644,7 @@ wss.on('connection', (ws, req) => {
         let modified = [];
         try {
           const { execSync } = require('child_process');
-          const status = execSync('git status --porcelain', { cwd: targetPath, encoding: 'utf8', maxBuffer: 512 * 1024 });
+          const status = execSync('git status --porcelain', { cwd: targetPath, encoding: 'utf8', maxBuffer: 512 * 1024, windowsHide: true, timeout: 10000 });
           modified = status.split('\n').filter(Boolean).map(l => l.slice(3).trim());
         } catch {}
         ws.send(JSON.stringify({ type: 'file_list', root: targetPath, tree, modified }));
@@ -1704,7 +1704,7 @@ wss.on('connection', (ws, req) => {
       if (fs.existsSync(wd.path)) {
         try {
           const { execSync } = require('child_process');
-          const diff = execSync('git diff', { cwd: wd.path, encoding: 'utf8', maxBuffer: 1024 * 1024 });
+          const diff = execSync('git diff', { cwd: wd.path, encoding: 'utf8', maxBuffer: 1024 * 1024, windowsHide: true, timeout: 10000 });
           const parsed = parseGitDiff(diff);
           ws.send(JSON.stringify({ type: 'git_diff', files: parsed }));
         } catch (e) { ws.send(JSON.stringify({ type: 'git_diff', error: e.message })); }

--- a/server.js
+++ b/server.js
@@ -1573,6 +1573,44 @@ wss.on('connection', (ws, req) => {
       pendingAgents.delete(msg.message_id);
       pendingActorMeta.delete(msg.message_id);
     }
+    // ── File operations (workspace panel) ──────────────────────────────────
+    if (msg.type === 'file_list' && subscribedRoom) {
+      const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(subscribedRoom);
+      if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'file_list', error: 'no workdir' })); return; }
+      const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
+      if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_list', error: 'workdir not found' })); return; }
+      try {
+        const tree = buildFileTree(wd.path, wd.path, 0, 3);
+        ws.send(JSON.stringify({ type: 'file_list', root: wd.path, tree }));
+      } catch (e) { ws.send(JSON.stringify({ type: 'file_list', error: e.message })); }
+    }
+
+    if (msg.type === 'file_read' && subscribedRoom) {
+      const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(subscribedRoom);
+      if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'file_read', error: 'no workdir' })); return; }
+      const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
+      if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_read', error: 'workdir not found' })); return; }
+      const filePath = path.resolve(wd.path, msg.path);
+      if (!filePath.startsWith(path.resolve(wd.path))) { ws.send(JSON.stringify({ type: 'file_read', error: 'path traversal blocked' })); return; }
+      try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        ws.send(JSON.stringify({ type: 'file_read', path: msg.path, content }));
+      } catch (e) { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: e.message })); }
+    }
+
+    if (msg.type === 'git_diff' && subscribedRoom) {
+      const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(subscribedRoom);
+      if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'git_diff', error: 'no workdir' })); return; }
+      const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
+      if (!wd?.path) { ws.send(JSON.stringify({ type: 'git_diff', error: 'workdir not found' })); return; }
+      try {
+        const { execSync } = require('child_process');
+        const diff = execSync('git diff', { cwd: wd.path, encoding: 'utf8', maxBuffer: 1024 * 1024 });
+        const parsed = parseGitDiff(diff);
+        ws.send(JSON.stringify({ type: 'git_diff', files: parsed }));
+      } catch (e) { ws.send(JSON.stringify({ type: 'git_diff', error: e.message })); }
+    }
+
    } catch (err) { console.error('[ws] unhandled message error:', err); }
   });
 
@@ -1591,6 +1629,54 @@ wss.on('connection', (ws, req) => {
     }
   });
 });
+
+// ─── Workspace helpers ──────────────────────────────────────────────────────
+
+const WS_IGNORE = new Set(['.git', 'node_modules', '.next', '__pycache__', '.venv', 'dist', 'build', '.claude']);
+
+function buildFileTree(dirPath, rootPath, depth, maxDepth) {
+  if (depth > maxDepth) return [];
+  let entries;
+  try { entries = fs.readdirSync(dirPath, { withFileTypes: true }); } catch { return []; }
+  const result = [];
+  const dirs = entries.filter(e => e.isDirectory() && !WS_IGNORE.has(e.name) && !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name));
+  const files = entries.filter(e => e.isFile() && !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name));
+  for (const d of dirs) {
+    const children = buildFileTree(path.join(dirPath, d.name), rootPath, depth + 1, maxDepth);
+    result.push({ t: 'folder', name: d.name, depth, open: depth < 1, children });
+  }
+  for (const f of files) {
+    const ext = path.extname(f.name).slice(1);
+    result.push({ t: ext || 'file', name: f.name, depth });
+  }
+  return result;
+}
+
+function parseGitDiff(raw) {
+  if (!raw.trim()) return [];
+  const files = [];
+  let current = null;
+  for (const line of raw.split('\n')) {
+    if (line.startsWith('diff --git')) {
+      const match = line.match(/b\/(.+)$/);
+      current = { name: match ? match[1] : '?', hunks: [], add: 0, del: 0 };
+      files.push(current);
+    } else if (line.startsWith('@@') && current) {
+      current.hunks.push({ k: 'hunk', text: line });
+    } else if (current && current.hunks.length) {
+      if (line.startsWith('+') && !line.startsWith('+++')) {
+        current.hunks.push({ k: 'add', text: line.slice(1) });
+        current.add++;
+      } else if (line.startsWith('-') && !line.startsWith('---')) {
+        current.hunks.push({ k: 'del', text: line.slice(1) });
+        current.del++;
+      } else if (line.startsWith(' ')) {
+        current.hunks.push({ k: 'ctx', text: line.slice(1) });
+      }
+    }
+  }
+  return files;
+}
 
 // ─── Message handling ─────────────────────────────────────────────────────────
 

--- a/server.js
+++ b/server.js
@@ -1287,7 +1287,7 @@ Write-Host "Logs   : pm2 logs $AgentName"
   res.end('Not found');
   } catch (err) {
     console.error('[http] unhandled error:', err.message);
-    if (!res.headersSent) { res.writeHead(400); res.end(JSON.stringify({ error: 'Bad request' })); }
+    if (!res.headersSent) { res.writeHead(500); res.end(JSON.stringify({ error: 'Internal server error' })); }
   }
 });
 

--- a/server.js
+++ b/server.js
@@ -921,7 +921,8 @@ const server = http.createServer(async (req, res) => {
     const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
     if (!wd?.path) { res.writeHead(404); return res.end('workdir not found'); }
     const filePath = path.resolve(wd.path, relPath);
-    if (!filePath.startsWith(path.resolve(wd.path))) { res.writeHead(403); return res.end('path traversal blocked'); }
+    const wdResolved = path.resolve(wd.path) + path.sep;
+    if (!filePath.startsWith(wdResolved) && filePath !== path.resolve(wd.path)) { res.writeHead(403); return res.end('path traversal blocked'); }
     if (!fs.existsSync(filePath)) { res.writeHead(404); return res.end('not found'); }
     const ext = path.extname(filePath).toLowerCase();
     const mimeMap = { '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif', '.webp': 'image/webp', '.svg': 'image/svg+xml', '.ico': 'image/x-icon', '.bmp': 'image/bmp', '.pdf': 'application/pdf' };
@@ -1626,7 +1627,9 @@ wss.on('connection', (ws, req) => {
       const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_list', error: 'workdir not found' })); return; }
       const targetPath = msg.abs_path || wd.path;
-      if (fs.existsSync(targetPath)) {
+      const isLocal = fs.existsSync(targetPath);
+      const isBounded = !msg.abs_path || path.resolve(targetPath).startsWith(path.resolve(wd.path) + path.sep) || path.resolve(targetPath) === path.resolve(wd.path);
+      if (isLocal && isBounded) {
         const tree = buildFileTree(targetPath, targetPath, 0, 3);
         ws.send(JSON.stringify({ type: 'file_list', root: targetPath, tree }));
       } else {
@@ -1644,8 +1647,19 @@ wss.on('connection', (ws, req) => {
       if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'file_read', error: 'no workdir' })); return; }
       const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_read', error: 'workdir not found' })); return; }
-      const resolveBase = msg.absolute ? '/' : wd.path;
-      const filePath = msg.absolute ? msg.path : path.resolve(wd.path, msg.path);
+      if (msg.absolute) {
+        const agentWs = agentClients.get(wd.actor_id);
+        if (agentWs) {
+          const rid = crypto.randomBytes(6).toString('hex');
+          pendingFileOps.set(rid, { type: 'file_read', clientWs: ws, originalPath: msg.path });
+          agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: path.dirname(msg.path), path: path.basename(msg.path), binary: !!msg.binary }));
+        } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
+        return;
+      }
+      const filePath = path.resolve(wd.path, msg.path);
+      if (!filePath.startsWith(path.resolve(wd.path) + path.sep) && filePath !== path.resolve(wd.path)) {
+        ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'path traversal blocked' })); return;
+      }
       if (fs.existsSync(filePath)) {
         try {
           if (msg.binary) {
@@ -1661,9 +1675,7 @@ wss.on('connection', (ws, req) => {
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
           pendingFileOps.set(rid, { type: 'file_read', clientWs: ws, originalPath: msg.path });
-          const proxyWorkdir = msg.absolute ? path.dirname(msg.path) : wd.path;
-          const proxyPath = msg.absolute ? path.basename(msg.path) : msg.path;
-          agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: proxyWorkdir, path: proxyPath, binary: !!msg.binary }));
+          agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: wd.path, path: msg.path, binary: !!msg.binary }));
         } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
       }
     }

--- a/server.js
+++ b/server.js
@@ -1597,7 +1597,7 @@ wss.on('connection', (ws, req) => {
       const op = pendingFileOps.get(msg.request_id);
       if (op && op.clientWs.readyState === 1) {
         if (msg.error) op.clientWs.send(JSON.stringify({ type: 'file_list', error: msg.error }));
-        else op.clientWs.send(JSON.stringify({ type: 'file_list', root: msg.root, tree: msg.tree }));
+        else op.clientWs.send(JSON.stringify({ type: 'file_list', root: msg.root, tree: msg.tree, modified: msg.modified || [] }));
       }
       pendingFileOps.delete(msg.request_id);
     }
@@ -1632,7 +1632,13 @@ wss.on('connection', (ws, req) => {
       const isBounded = !msg.abs_path || path.resolve(targetPath).startsWith(path.resolve(wd.path) + path.sep) || path.resolve(targetPath) === path.resolve(wd.path);
       if (isLocal && isBounded) {
         const tree = buildFileTree(targetPath, targetPath, 0, 3);
-        ws.send(JSON.stringify({ type: 'file_list', root: targetPath, tree }));
+        let modified = [];
+        try {
+          const { execSync } = require('child_process');
+          const status = execSync('git status --porcelain', { cwd: targetPath, encoding: 'utf8', maxBuffer: 512 * 1024 });
+          modified = status.split('\n').filter(Boolean).map(l => l.slice(3).trim());
+        } catch {}
+        ws.send(JSON.stringify({ type: 'file_list', root: targetPath, tree, modified }));
       } else {
         const agentWs = agentClients.get(wd.actor_id);
         if (agentWs) {

--- a/server.js
+++ b/server.js
@@ -911,6 +911,26 @@ const server = http.createServer(async (req, res) => {
     return res.end(fs.readFileSync(fp, 'utf8'));
   }
 
+  // ── Workspace file serve (images, binary files) ──
+  if (req.method === 'GET' && url.pathname.startsWith('/api/workspace/file/')) {
+    const roomId = url.searchParams.get('room');
+    if (!roomId) { res.writeHead(400); return res.end('missing room'); }
+    const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(roomId);
+    if (!roomRow?.workdir_id) { res.writeHead(404); return res.end('no workdir'); }
+    const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
+    if (!wd?.path) { res.writeHead(404); return res.end('workdir not found'); }
+    const relPath = decodeURIComponent(url.pathname.slice('/api/workspace/file/'.length));
+    const filePath = path.resolve(wd.path, relPath);
+    if (!filePath.startsWith(path.resolve(wd.path))) { res.writeHead(403); return res.end('path traversal blocked'); }
+    if (!fs.existsSync(filePath)) { res.writeHead(404); return res.end('not found'); }
+    const ext = path.extname(filePath).toLowerCase();
+    const mimeMap = { '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif', '.webp': 'image/webp', '.svg': 'image/svg+xml', '.ico': 'image/x-icon', '.bmp': 'image/bmp', '.pdf': 'application/pdf' };
+    const mime = mimeMap[ext] || 'application/octet-stream';
+    const data = fs.readFileSync(filePath);
+    res.writeHead(200, { 'Content-Type': mime, 'Content-Length': data.length, 'Cache-Control': 'no-cache' });
+    return res.end(data);
+  }
+
   // ── Agent install script ──
   if (req.method === 'GET' && url.pathname === '/install.sh') {
     const host = req.headers.host || `localhost:${PORT}`;

--- a/server.js
+++ b/server.js
@@ -1613,6 +1613,15 @@ wss.on('connection', (ws, req) => {
       pendingFileOps.delete(msg.request_id);
     }
 
+    if (msg.type === 'proxy_git_diff_result' && agentActorId) {
+      const op = pendingFileOps.get(msg.request_id);
+      if (op && op.clientWs.readyState === 1) {
+        if (msg.error) op.clientWs.send(JSON.stringify({ type: 'git_diff', error: msg.error }));
+        else op.clientWs.send(JSON.stringify({ type: 'git_diff', files: msg.files || [] }));
+      }
+      pendingFileOps.delete(msg.request_id);
+    }
+
     // ── Agent error
     if (msg.type === 'agent_error' && agentActorId) {
       db.prepare(`UPDATE messages SET state='error' WHERE id=?`).run(msg.message_id);
@@ -1690,14 +1699,23 @@ wss.on('connection', (ws, req) => {
     if (msg.type === 'git_diff' && subscribedRoom) {
       const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(subscribedRoom);
       if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'git_diff', error: 'no workdir' })); return; }
-      const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
+      const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'git_diff', error: 'workdir not found' })); return; }
-      try {
-        const { execSync } = require('child_process');
-        const diff = execSync('git diff', { cwd: wd.path, encoding: 'utf8', maxBuffer: 1024 * 1024 });
-        const parsed = parseGitDiff(diff);
-        ws.send(JSON.stringify({ type: 'git_diff', files: parsed }));
-      } catch (e) { ws.send(JSON.stringify({ type: 'git_diff', error: e.message })); }
+      if (fs.existsSync(wd.path)) {
+        try {
+          const { execSync } = require('child_process');
+          const diff = execSync('git diff', { cwd: wd.path, encoding: 'utf8', maxBuffer: 1024 * 1024 });
+          const parsed = parseGitDiff(diff);
+          ws.send(JSON.stringify({ type: 'git_diff', files: parsed }));
+        } catch (e) { ws.send(JSON.stringify({ type: 'git_diff', error: e.message })); }
+      } else {
+        const agentWs = agentClients.get(wd.actor_id);
+        if (agentWs) {
+          const rid = crypto.randomBytes(6).toString('hex');
+          pendingFileOps.set(rid, { type: 'git_diff', clientWs: ws });
+          agentWs.send(JSON.stringify({ type: 'proxy_git_diff', request_id: rid, workdir: wd.path }));
+        } else { ws.send(JSON.stringify({ type: 'git_diff', error: 'agent offline' })); }
+      }
     }
 
    } catch (err) { console.error('[ws] unhandled message error:', err); }

--- a/server.js
+++ b/server.js
@@ -1602,10 +1602,13 @@ wss.on('connection', (ws, req) => {
 
     if (msg.type === 'proxy_file_read_result' && agentActorId) {
       const op = pendingFileOps.get(msg.request_id);
+      console.log('[ws-file] proxy_file_read_result rid:', msg.request_id, 'op:', !!op, 'wsReady:', op?.clientWs?.readyState, 'error:', msg.error || 'none', 'hasContent:', !!(msg.content || msg.base64));
       if (op && op.clientWs.readyState === 1) {
         if (msg.error) op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, error: msg.error }));
         else if (msg.base64) op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, base64: msg.base64 }));
         else op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, content: msg.content }));
+      } else {
+        console.log('[ws-file] DROPPED — op missing or ws closed');
       }
       pendingFileOps.delete(msg.request_id);
     }
@@ -1663,6 +1666,7 @@ wss.on('connection', (ws, req) => {
           const proxyWorkdir = msg.absolute ? path.dirname(msg.path) : wd.path;
           const proxyPath = msg.absolute ? path.basename(msg.path) : msg.path;
           agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: proxyWorkdir, path: proxyPath, binary: !!msg.binary }));
+          console.log('[ws-file] proxy_file_read sent rid:', rid, 'workdir:', proxyWorkdir, 'path:', proxyPath);
         } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
       }
     }

--- a/server.js
+++ b/server.js
@@ -1600,6 +1600,7 @@ wss.on('connection', (ws, req) => {
       const op = pendingFileOps.get(msg.request_id);
       if (op && op.clientWs.readyState === 1) {
         if (msg.error) op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, error: msg.error }));
+        else if (msg.base64) op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, base64: msg.base64 }));
         else op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, content: msg.content }));
       }
       pendingFileOps.delete(msg.request_id);
@@ -1642,8 +1643,13 @@ wss.on('connection', (ws, req) => {
       const filePath = msg.absolute ? msg.path : path.resolve(wd.path, msg.path);
       if (fs.existsSync(filePath)) {
         try {
-          const content = fs.readFileSync(filePath, 'utf8');
-          ws.send(JSON.stringify({ type: 'file_read', path: msg.path, content }));
+          if (msg.binary) {
+            const data = fs.readFileSync(filePath);
+            ws.send(JSON.stringify({ type: 'file_read', path: msg.path, base64: data.toString('base64') }));
+          } else {
+            const content = fs.readFileSync(filePath, 'utf8');
+            ws.send(JSON.stringify({ type: 'file_read', path: msg.path, content }));
+          }
         } catch (e) { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: e.message })); }
       } else {
         const agentWs = agentClients.get(wd.actor_id);
@@ -1652,7 +1658,7 @@ wss.on('connection', (ws, req) => {
           pendingFileOps.set(rid, { type: 'file_read', clientWs: ws });
           const proxyWorkdir = msg.absolute ? path.dirname(msg.path) : wd.path;
           const proxyPath = msg.absolute ? path.basename(msg.path) : msg.path;
-          agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: proxyWorkdir, path: proxyPath }));
+          agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: proxyWorkdir, path: proxyPath, binary: !!msg.binary }));
         } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
       }
     }

--- a/server.js
+++ b/server.js
@@ -1299,6 +1299,7 @@ const agentClients = new Map();   // actor_id → ws
 const agentVersions = new Map();  // actor_id → client_version string
 const pendingAgents = new Map();    // message_id → { resolve, reject }
 const pendingActorMeta = new Map(); // message_id → { name, avatar_color, avatar_symbol }
+const pendingFileOps = new Map();   // request_id → { type, clientWs }
 
 function broadcastGlobal(data) {
   const str = JSON.stringify(data);
@@ -1585,6 +1586,25 @@ wss.on('connection', (ws, req) => {
       pendingActorMeta.delete(msg.message_id);
     }
 
+    // ── Agent proxy file responses
+    if (msg.type === 'proxy_file_list_result' && agentActorId) {
+      const op = pendingFileOps.get(msg.request_id);
+      if (op && op.clientWs.readyState === 1) {
+        if (msg.error) op.clientWs.send(JSON.stringify({ type: 'file_list', error: msg.error }));
+        else op.clientWs.send(JSON.stringify({ type: 'file_list', root: msg.root, tree: msg.tree }));
+      }
+      pendingFileOps.delete(msg.request_id);
+    }
+
+    if (msg.type === 'proxy_file_read_result' && agentActorId) {
+      const op = pendingFileOps.get(msg.request_id);
+      if (op && op.clientWs.readyState === 1) {
+        if (msg.error) op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, error: msg.error }));
+        else op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, content: msg.content }));
+      }
+      pendingFileOps.delete(msg.request_id);
+    }
+
     // ── Agent error
     if (msg.type === 'agent_error' && agentActorId) {
       db.prepare(`UPDATE messages SET state='error' WHERE id=?`).run(msg.message_id);
@@ -1597,26 +1617,39 @@ wss.on('connection', (ws, req) => {
     if (msg.type === 'file_list' && subscribedRoom) {
       const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(subscribedRoom);
       if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'file_list', error: 'no workdir' })); return; }
-      const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
+      const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_list', error: 'workdir not found' })); return; }
       try {
         const tree = buildFileTree(wd.path, wd.path, 0, 3);
         ws.send(JSON.stringify({ type: 'file_list', root: wd.path, tree }));
-      } catch (e) { ws.send(JSON.stringify({ type: 'file_list', error: e.message })); }
+      } catch {
+        const agentWs = agentClients.get(wd.actor_id);
+        if (agentWs) {
+          const rid = crypto.randomBytes(6).toString('hex');
+          pendingFileOps.set(rid, { type: 'file_list', clientWs: ws });
+          agentWs.send(JSON.stringify({ type: 'proxy_file_list', request_id: rid, workdir: wd.path }));
+        } else { ws.send(JSON.stringify({ type: 'file_list', error: 'agent offline' })); }
+      }
     }
 
     if (msg.type === 'file_read' && subscribedRoom) {
       const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(subscribedRoom);
       if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'file_read', error: 'no workdir' })); return; }
-      const wd = db.prepare('SELECT path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
+      const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_read', error: 'workdir not found' })); return; }
       const filePath = path.resolve(wd.path, msg.path);
       if (!filePath.startsWith(path.resolve(wd.path))) { ws.send(JSON.stringify({ type: 'file_read', error: 'path traversal blocked' })); return; }
       try {
         const content = fs.readFileSync(filePath, 'utf8');
         ws.send(JSON.stringify({ type: 'file_read', path: msg.path, content }));
-      } catch (e) { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: e.message })); }
-    }
+      } catch {
+        const agentWs = agentClients.get(wd.actor_id);
+        if (agentWs) {
+          const rid = crypto.randomBytes(6).toString('hex');
+          pendingFileOps.set(rid, { type: 'file_read', clientWs: ws });
+          agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: wd.path, path: msg.path }));
+        } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
+      }
 
     if (msg.type === 'git_diff' && subscribedRoom) {
       const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(subscribedRoom);

--- a/server.js
+++ b/server.js
@@ -1602,13 +1602,11 @@ wss.on('connection', (ws, req) => {
 
     if (msg.type === 'proxy_file_read_result' && agentActorId) {
       const op = pendingFileOps.get(msg.request_id);
-      console.log('[ws-file] proxy_file_read_result rid:', msg.request_id, 'op:', !!op, 'wsReady:', op?.clientWs?.readyState, 'error:', msg.error || 'none', 'hasContent:', !!(msg.content || msg.base64));
       if (op && op.clientWs.readyState === 1) {
-        if (msg.error) op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, error: msg.error }));
-        else if (msg.base64) op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, base64: msg.base64 }));
-        else op.clientWs.send(JSON.stringify({ type: 'file_read', path: msg.path, content: msg.content }));
-      } else {
-        console.log('[ws-file] DROPPED — op missing or ws closed');
+        const p = op.originalPath || msg.path;
+        if (msg.error) op.clientWs.send(JSON.stringify({ type: 'file_read', path: p, error: msg.error }));
+        else if (msg.base64) op.clientWs.send(JSON.stringify({ type: 'file_read', path: p, base64: msg.base64 }));
+        else op.clientWs.send(JSON.stringify({ type: 'file_read', path: p, content: msg.content }));
       }
       pendingFileOps.delete(msg.request_id);
     }
@@ -1662,11 +1660,10 @@ wss.on('connection', (ws, req) => {
         const agentWs = agentClients.get(wd.actor_id);
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
-          pendingFileOps.set(rid, { type: 'file_read', clientWs: ws });
+          pendingFileOps.set(rid, { type: 'file_read', clientWs: ws, originalPath: msg.path });
           const proxyWorkdir = msg.absolute ? path.dirname(msg.path) : wd.path;
           const proxyPath = msg.absolute ? path.basename(msg.path) : msg.path;
           agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: proxyWorkdir, path: proxyPath, binary: !!msg.binary }));
-          console.log('[ws-file] proxy_file_read sent rid:', rid, 'workdir:', proxyWorkdir, 'path:', proxyPath);
         } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
       }
     }

--- a/server.js
+++ b/server.js
@@ -527,6 +527,7 @@ const server = http.createServer(async (req, res) => {
       FROM rooms r JOIN actors a ON a.id=r.created_by LEFT JOIN agent_workdirs w ON w.id=r.workdir_id
       WHERE ${archived ? 'r.archived_at IS NOT NULL' : 'r.archived_at IS NULL'}
       ORDER BY last_activity DESC
+      LIMIT 200
     `).all();
     return json(res, rows);
   }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const http = require('http');
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { execSync } = require('child_process');
 const { WebSocketServer } = require('ws');
 const db = require('./db');
 const { ClaudeSession } = require('./claude-session');
@@ -1302,6 +1303,10 @@ const agentVersions = new Map();  // actor_id → client_version string
 const pendingAgents = new Map();    // message_id → { resolve, reject }
 const pendingActorMeta = new Map(); // message_id → { name, avatar_color, avatar_symbol }
 const pendingFileOps = new Map();   // request_id → { type, clientWs }
+function addPendingFileOp(rid, op) {
+  pendingFileOps.set(rid, op);
+  setTimeout(() => pendingFileOps.delete(rid), 15000);
+}
 
 function broadcastGlobal(data) {
   const str = JSON.stringify(data);
@@ -1643,7 +1648,7 @@ wss.on('connection', (ws, req) => {
         const tree = buildFileTree(targetPath, targetPath, 0, 3);
         let modified = [];
         try {
-          const { execSync } = require('child_process');
+
           const status = execSync('git status --porcelain', { cwd: targetPath, encoding: 'utf8', maxBuffer: 512 * 1024, windowsHide: true, timeout: 10000 });
           modified = status.split('\n').filter(Boolean).map(l => l.slice(3).trim());
         } catch {}
@@ -1652,7 +1657,7 @@ wss.on('connection', (ws, req) => {
         const agentWs = agentClients.get(wd.actor_id);
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
-          pendingFileOps.set(rid, { type: 'file_list', clientWs: ws });
+          addPendingFileOp(rid, { type: 'file_list', clientWs: ws });
           agentWs.send(JSON.stringify({ type: 'proxy_file_list', request_id: rid, workdir: targetPath }));
         } else { ws.send(JSON.stringify({ type: 'file_list', error: 'agent offline' })); }
       }
@@ -1667,7 +1672,7 @@ wss.on('connection', (ws, req) => {
         const agentWs = agentClients.get(wd.actor_id);
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
-          pendingFileOps.set(rid, { type: 'file_read', clientWs: ws, originalPath: msg.path });
+          addPendingFileOp(rid, { type: 'file_read', clientWs: ws, originalPath: msg.path });
           agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: path.dirname(msg.path), path: path.basename(msg.path), binary: !!msg.binary }));
         } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
         return;
@@ -1690,7 +1695,7 @@ wss.on('connection', (ws, req) => {
         const agentWs = agentClients.get(wd.actor_id);
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
-          pendingFileOps.set(rid, { type: 'file_read', clientWs: ws, originalPath: msg.path });
+          addPendingFileOp(rid, { type: 'file_read', clientWs: ws, originalPath: msg.path });
           agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: wd.path, path: msg.path, binary: !!msg.binary }));
         } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
       }
@@ -1703,7 +1708,7 @@ wss.on('connection', (ws, req) => {
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'git_diff', error: 'workdir not found' })); return; }
       if (fs.existsSync(wd.path)) {
         try {
-          const { execSync } = require('child_process');
+
           const diff = execSync('git diff', { cwd: wd.path, encoding: 'utf8', maxBuffer: 1024 * 1024, windowsHide: true, timeout: 10000 });
           const parsed = parseGitDiff(diff);
           ws.send(JSON.stringify({ type: 'git_diff', files: parsed }));
@@ -1712,7 +1717,7 @@ wss.on('connection', (ws, req) => {
         const agentWs = agentClients.get(wd.actor_id);
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
-          pendingFileOps.set(rid, { type: 'git_diff', clientWs: ws });
+          addPendingFileOp(rid, { type: 'git_diff', clientWs: ws });
           agentWs.send(JSON.stringify({ type: 'proxy_git_diff', request_id: rid, workdir: wd.path }));
         } else { ws.send(JSON.stringify({ type: 'git_diff', error: 'agent offline' })); }
       }

--- a/server.js
+++ b/server.js
@@ -1431,6 +1431,10 @@ wss.on('connection', (ws, req) => {
       if (reconnectCleaned.changes) console.log(`[agent] Cleaned ${reconnectCleaned.changes} orphaned message(s) on reconnect for Actor #${agentActorId}`);
       if (msg.client_version) agentVersions.set(agentActorId, msg.client_version);
       console.log(`[agent] Actor #${agentActorId} connected (v${msg.client_version || '?'})`);
+      if (EXPECTED_CLIENT_VERSION && msg.client_version && msg.client_version.localeCompare(EXPECTED_CLIENT_VERSION, undefined, { numeric: true }) < 0) {
+        console.log(`[agent] Actor #${agentActorId} outdated (v${msg.client_version} < v${EXPECTED_CLIENT_VERSION}), sending force_update`);
+        ws.send(JSON.stringify({ type: 'force_update' }));
+      }
       ws.send(JSON.stringify({ type: 'agent_ready' }));
       ws.send(JSON.stringify({ type: 'set_config', max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 1, session_idle_ttl: parseInt(process.env.SESSION_IDLE_TTL) || 5 }));
       const connectedActor = db.prepare('SELECT id, name, type, avatar_color, avatar_symbol, avatar_url, created_at FROM actors WHERE id=?').get(agentActorId);

--- a/server.js
+++ b/server.js
@@ -1650,6 +1650,7 @@ wss.on('connection', (ws, req) => {
           agentWs.send(JSON.stringify({ type: 'proxy_file_read', request_id: rid, workdir: wd.path, path: msg.path }));
         } else { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: 'agent offline' })); }
       }
+    }
 
     if (msg.type === 'git_diff' && subscribedRoom) {
       const roomRow = db.prepare('SELECT workdir_id FROM rooms WHERE id=?').get(subscribedRoom);

--- a/server.js
+++ b/server.js
@@ -1619,15 +1619,18 @@ wss.on('connection', (ws, req) => {
       if (!roomRow?.workdir_id) { ws.send(JSON.stringify({ type: 'file_list', error: 'no workdir' })); return; }
       const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_list', error: 'workdir not found' })); return; }
-      try {
+      const localExists = fs.existsSync(wd.path);
+      if (localExists) {
         const tree = buildFileTree(wd.path, wd.path, 0, 3);
         ws.send(JSON.stringify({ type: 'file_list', root: wd.path, tree }));
-      } catch {
+      } else {
         const agentWs = agentClients.get(wd.actor_id);
+        console.log('[ws-file] agent ws for actor', wd.actor_id, ':', agentWs ? 'found' : 'NOT FOUND');
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');
           pendingFileOps.set(rid, { type: 'file_list', clientWs: ws });
           agentWs.send(JSON.stringify({ type: 'proxy_file_list', request_id: rid, workdir: wd.path }));
+          console.log('[ws-file] proxy_file_list sent to agent, rid:', rid);
         } else { ws.send(JSON.stringify({ type: 'file_list', error: 'agent offline' })); }
       }
     }
@@ -1638,11 +1641,12 @@ wss.on('connection', (ws, req) => {
       const wd = db.prepare('SELECT actor_id, path FROM agent_workdirs WHERE id=?').get(roomRow.workdir_id);
       if (!wd?.path) { ws.send(JSON.stringify({ type: 'file_read', error: 'workdir not found' })); return; }
       const filePath = path.resolve(wd.path, msg.path);
-      if (!filePath.startsWith(path.resolve(wd.path))) { ws.send(JSON.stringify({ type: 'file_read', error: 'path traversal blocked' })); return; }
-      try {
-        const content = fs.readFileSync(filePath, 'utf8');
-        ws.send(JSON.stringify({ type: 'file_read', path: msg.path, content }));
-      } catch {
+      if (fs.existsSync(filePath)) {
+        try {
+          const content = fs.readFileSync(filePath, 'utf8');
+          ws.send(JSON.stringify({ type: 'file_read', path: msg.path, content }));
+        } catch (e) { ws.send(JSON.stringify({ type: 'file_read', path: msg.path, error: e.message })); }
+      } else {
         const agentWs = agentClients.get(wd.actor_id);
         if (agentWs) {
           const rid = crypto.randomBytes(6).toString('hex');

--- a/stoa.js
+++ b/stoa.js
@@ -60,6 +60,25 @@ const UPDATE_FILES = AI_BACKEND === 'gemini'
   ? ['stoa.js', 'gemini-session.js', 'gemini-adapter.js']
   : ['stoa.js', 'claude-session.js'];
 
+const TREE_IGNORE = new Set(['.git', 'node_modules', '.next', '__pycache__', '.venv', 'dist', 'build', '.claude']);
+function buildFileTreeAgent(dirPath, rootPath, depth, maxDepth) {
+  if (depth > maxDepth) return [];
+  let entries;
+  try { entries = fs.readdirSync(dirPath, { withFileTypes: true }); } catch { return []; }
+  const result = [];
+  const dirs = entries.filter(e => e.isDirectory() && !TREE_IGNORE.has(e.name) && !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name));
+  const files = entries.filter(e => e.isFile() && !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name));
+  for (const d of dirs) {
+    const children = buildFileTreeAgent(path.join(dirPath, d.name), rootPath, depth + 1, maxDepth);
+    result.push({ t: 'folder', name: d.name, depth, open: depth < 1, children });
+  }
+  for (const f of files) {
+    const ext = path.extname(f.name).slice(1);
+    result.push({ t: ext || 'file', name: f.name, depth });
+  }
+  return result;
+}
+
 function buildLocalManifest() {
   const manifest = {};
   for (const name of UPDATE_FILES) {
@@ -296,6 +315,29 @@ async function handleAgentMessage(msg) {
       } catch {}
     }
     send({ type: 'model_info', workdir: msg.workdir, model });
+  }
+
+  if (msg.type === 'proxy_file_list') {
+    try {
+      const tree = buildFileTreeAgent(msg.workdir, msg.workdir, 0, 3);
+      send({ type: 'proxy_file_list_result', request_id: msg.request_id, root: msg.workdir, tree });
+    } catch (e) {
+      send({ type: 'proxy_file_list_result', request_id: msg.request_id, error: e.message });
+    }
+  }
+
+  if (msg.type === 'proxy_file_read') {
+    try {
+      const filePath = path.resolve(msg.workdir, msg.path);
+      if (!filePath.startsWith(path.resolve(msg.workdir))) {
+        send({ type: 'proxy_file_read_result', request_id: msg.request_id, error: 'path traversal blocked' });
+        return;
+      }
+      const content = fs.readFileSync(filePath, 'utf8');
+      send({ type: 'proxy_file_read_result', request_id: msg.request_id, path: msg.path, content });
+    } catch (e) {
+      send({ type: 'proxy_file_read_result', request_id: msg.request_id, path: msg.path, error: e.message });
+    }
   }
 
   if (msg.type === 'search_result' || msg.type === 'get_message_result') {

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.2.36';
+const CLIENT_VERSION = '0.2.37';
 
 const WebSocket = require('ws');
 const readline = require('readline');
@@ -322,7 +322,7 @@ async function handleAgentMessage(msg) {
       const tree = buildFileTreeAgent(msg.workdir, msg.workdir, 0, 3);
       let modified = [];
       try {
-        const status = spawnSync('git', ['status', '--porcelain'], { cwd: msg.workdir, encoding: 'utf8', maxBuffer: 512 * 1024 });
+        const status = spawnSync('git', ['status', '--porcelain'], { cwd: msg.workdir, encoding: 'utf8', maxBuffer: 512 * 1024, windowsHide: true, timeout: 10000 });
         if (status.stdout) modified = status.stdout.split('\n').filter(Boolean).map(l => l.slice(3).trim());
       } catch {}
       send({ type: 'proxy_file_list_result', request_id: msg.request_id, root: msg.workdir, tree, modified });
@@ -352,7 +352,7 @@ async function handleAgentMessage(msg) {
 
   if (msg.type === 'proxy_git_diff') {
     try {
-      const status = spawnSync('git', ['diff'], { cwd: msg.workdir, encoding: 'utf8', maxBuffer: 1024 * 1024 });
+      const status = spawnSync('git', ['diff'], { cwd: msg.workdir, encoding: 'utf8', maxBuffer: 1024 * 1024, windowsHide: true, timeout: 10000 });
       const raw = status.stdout || '';
       const files = [];
       let current = null;

--- a/stoa.js
+++ b/stoa.js
@@ -333,8 +333,13 @@ async function handleAgentMessage(msg) {
         send({ type: 'proxy_file_read_result', request_id: msg.request_id, error: 'path traversal blocked' });
         return;
       }
-      const content = fs.readFileSync(filePath, 'utf8');
-      send({ type: 'proxy_file_read_result', request_id: msg.request_id, path: msg.path, content });
+      if (msg.binary) {
+        const data = fs.readFileSync(filePath);
+        send({ type: 'proxy_file_read_result', request_id: msg.request_id, path: msg.path, base64: data.toString('base64') });
+      } else {
+        const content = fs.readFileSync(filePath, 'utf8');
+        send({ type: 'proxy_file_read_result', request_id: msg.request_id, path: msg.path, content });
+      }
     } catch (e) {
       send({ type: 'proxy_file_read_result', request_id: msg.request_id, path: msg.path, error: e.message });
     }

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.2.32';
+const CLIENT_VERSION = '0.2.33';
 
 const WebSocket = require('ws');
 const readline = require('readline');

--- a/stoa.js
+++ b/stoa.js
@@ -320,7 +320,12 @@ async function handleAgentMessage(msg) {
   if (msg.type === 'proxy_file_list') {
     try {
       const tree = buildFileTreeAgent(msg.workdir, msg.workdir, 0, 3);
-      send({ type: 'proxy_file_list_result', request_id: msg.request_id, root: msg.workdir, tree });
+      let modified = [];
+      try {
+        const status = spawnSync('git', ['status', '--porcelain'], { cwd: msg.workdir, encoding: 'utf8', maxBuffer: 512 * 1024 });
+        if (status.stdout) modified = status.stdout.split('\n').filter(Boolean).map(l => l.slice(3).trim());
+      } catch {}
+      send({ type: 'proxy_file_list_result', request_id: msg.request_id, root: msg.workdir, tree, modified });
     } catch (e) {
       send({ type: 'proxy_file_list_result', request_id: msg.request_id, error: e.message });
     }

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.2.35';
+const CLIENT_VERSION = '0.2.36';
 
 const WebSocket = require('ws');
 const readline = require('readline');
@@ -347,6 +347,31 @@ async function handleAgentMessage(msg) {
       }
     } catch (e) {
       send({ type: 'proxy_file_read_result', request_id: msg.request_id, path: msg.path, error: e.message });
+    }
+  }
+
+  if (msg.type === 'proxy_git_diff') {
+    try {
+      const status = spawnSync('git', ['diff'], { cwd: msg.workdir, encoding: 'utf8', maxBuffer: 1024 * 1024 });
+      const raw = status.stdout || '';
+      const files = [];
+      let current = null;
+      for (const line of raw.split('\n')) {
+        if (line.startsWith('diff --git')) {
+          const match = line.match(/b\/(.+)$/);
+          current = { name: match ? match[1] : '?', hunks: [], add: 0, del: 0 };
+          files.push(current);
+        } else if (line.startsWith('@@') && current) {
+          current.hunks.push({ k: 'hunk', text: line });
+        } else if (current && current.hunks.length) {
+          if (line.startsWith('+') && !line.startsWith('+++')) { current.hunks.push({ k: 'add', text: line.slice(1) }); current.add++; }
+          else if (line.startsWith('-') && !line.startsWith('---')) { current.hunks.push({ k: 'del', text: line.slice(1) }); current.del++; }
+          else if (line.startsWith(' ')) { current.hunks.push({ k: 'ctx', text: line.slice(1) }); }
+        }
+      }
+      send({ type: 'proxy_git_diff_result', request_id: msg.request_id, files });
+    } catch (e) {
+      send({ type: 'proxy_git_diff_result', request_id: msg.request_id, error: e.message });
     }
   }
 

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.2.34';
+const CLIENT_VERSION = '0.2.35';
 
 const WebSocket = require('ws');
 const readline = require('readline');

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.2.33';
+const CLIENT_VERSION = '0.2.34';
 
 const WebSocket = require('ws');
 const readline = require('readline');


### PR DESCRIPTION
## Summary

- **Workspace panel** — resizable split-pane to the right of chat with file tree, code viewer (syntax highlighted), markdown preview, image preview, and git diff viewer
- **Remote file browsing** — proxy file operations through agent WebSocket, browse files on any machine the agent runs on from any device
- **Reading comfort controls** — text size, line spacing, bubble width settings in Settings > General, applied globally
- **Syntax highlighting** — highlight.js integration for chat code blocks and workspace code viewer (Hearth warm palette)
- **Clickable file paths** — file paths in chat messages become clickable links that open in workspace panel
- **Download files** — download button on each file in tree, fetches from remote agents via WebSocket
- **Sidebar collapse** — hide room list for more workspace space
- **Auto-refresh** — workspace updates automatically when agent edits files
- **Auto force-update agents** — outdated agents get updated on connect
- **Security hardening** — path traversal fixes, res.ok checks on all fetch calls
- **Documentation** — workspace panel, sidebar collapse, reading controls documented in EN + ID guides

## Test plan

- [ ] Open room, click workspace toggle — panel opens with file tree
- [ ] Click file — code viewer with syntax highlighting
- [ ] Click .md file — rendered markdown preview
- [ ] Click image file — image preview
- [ ] Click Git tab — shows uncommitted changes with diff
- [ ] Open remote agent room (Kira) — file tree loads via proxy
- [ ] Download file from remote agent — file downloads to local device
- [ ] Settings > General > Messages — adjust text size, verify chat + viewer scale together
- [ ] Click file path in chat message — opens in workspace panel
- [ ] Agent completes message — file tree and git diff auto-refresh
- [ ] Sidebar collapse button — hides sidebar, toggle in header restores it
- [ ] Hard refresh — sidebar always starts open, no blank screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)