### PR TITLE
add per-room automation queue system

### DIFF
--- a/changelog/version-.md
+++ b/changelog/version-.md
@@ -1,9 +1,14 @@
-# v — 2026-06-07
+# v — 2026-06-08
 
 ✨ New features
 
 ## Changes
 
+- fix queue-manager: emit error crash + missing drain cleanup
+- remove unnecessary 300ms delay in automation queue
+- use dedicated roomIdleBus instead of process for room idle signals
+- wrap triggerAgentsSequential in try/finally for reliable cleanup
+- add per-room automation queue system
 - show token plain text in edit connection form
 - show existing tokens pre-filled in edit connection form
 - show delete button on error state connections

--- a/queue-manager.js
+++ b/queue-manager.js
@@ -28,26 +28,28 @@ class QueueManager extends EventEmitter {
     if (this._running.get(key)) return;
     this._running.set(key, true);
 
-    const queue = this._queues.get(key);
-    while (queue && queue.length > 0) {
-      const { fn, meta, resolve, reject } = queue.shift();
-      this.emit('processing', { key, pending: queue.length, meta });
+    try {
+      const queue = this._queues.get(key);
+      while (queue && queue.length > 0) {
+        const { fn, meta, resolve, reject } = queue.shift();
+        this.emit('processing', { key, pending: queue.length, meta });
 
-      try {
-        const result = await fn();
-        this.emit('completed', { key, pending: queue.length, meta });
-        this._stats.totalProcessed++;
-        resolve(result);
-      } catch (e) {
-        this.emit('error', { key, error: e, pending: queue.length, meta });
-        this._stats.totalProcessed++;
-        reject(e);
+        try {
+          const result = await fn();
+          this.emit('completed', { key, pending: queue.length, meta });
+          this._stats.totalProcessed++;
+          resolve(result);
+        } catch (e) {
+          this.emit('item_error', { key, error: e, pending: queue.length, meta });
+          this._stats.totalProcessed++;
+          reject(e);
+        }
       }
+    } finally {
+      this._running.delete(key);
+      this._queues.delete(key);
+      this.emit('drained', { key });
     }
-
-    this._running.delete(key);
-    this._queues.delete(key);
-    this.emit('drained', { key });
   }
 
   pending(key) {

--- a/queue-manager.js
+++ b/queue-manager.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const EventEmitter = require('events');
+
+class QueueManager extends EventEmitter {
+  constructor() {
+    super();
+    this._queues = new Map();
+    this._running = new Map();
+    this._stats = { totalQueued: 0, totalProcessed: 0 };
+  }
+
+  enqueue(key, asyncFn, meta = {}) {
+    if (!this._queues.has(key)) this._queues.set(key, []);
+
+    return new Promise((resolve, reject) => {
+      this._queues.get(key).push({ fn: asyncFn, meta, resolve, reject });
+      this._stats.totalQueued++;
+
+      const pending = this._queues.get(key).length;
+      this.emit('enqueued', { key, pending, meta });
+
+      this._drain(key);
+    });
+  }
+
+  async _drain(key) {
+    if (this._running.get(key)) return;
+    this._running.set(key, true);
+
+    const queue = this._queues.get(key);
+    while (queue && queue.length > 0) {
+      const { fn, meta, resolve, reject } = queue.shift();
+      this.emit('processing', { key, pending: queue.length, meta });
+
+      try {
+        const result = await fn();
+        this.emit('completed', { key, pending: queue.length, meta });
+        this._stats.totalProcessed++;
+        resolve(result);
+      } catch (e) {
+        this.emit('error', { key, error: e, pending: queue.length, meta });
+        this._stats.totalProcessed++;
+        reject(e);
+      }
+    }
+
+    this._running.delete(key);
+    this._queues.delete(key);
+    this.emit('drained', { key });
+  }
+
+  pending(key) {
+    return this._queues.get(key)?.length || 0;
+  }
+
+  busy(key) {
+    return this._running.has(key);
+  }
+
+  stats() {
+    const activeRooms = [];
+    for (const [key, q] of this._queues) {
+      activeRooms.push({ room: key, pending: q.length, processing: this._running.has(key) });
+    }
+    return { ...this._stats, activeRooms };
+  }
+}
+
+module.exports = new QueueManager();

--- a/server.js
+++ b/server.js
@@ -23,6 +23,13 @@ function getFallbackSession(participantId, workDir) {
 }
 const { spawnGemini } = require('./gemini-adapter');
 const connectionManager = require('./connection-manager');
+const automationQueue = require('./queue-manager');
+automationQueue.on('processing', ({ key, pending, meta }) => {
+  if (pending > 0) console.log(`[queue] room ${key}: processing "${meta?.automation || 'unknown'}" (${pending} waiting)`);
+});
+automationQueue.on('drained', ({ key }) => {
+  console.log(`[queue] room ${key}: queue drained`);
+});
 
 const EXPECTED_CLIENT_VERSION = (() => {
   try {
@@ -2705,6 +2712,7 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
   }
 
   activeSequences.delete(roomId);
+  process.emit('stoa:room_idle', roomId);
 }
 
 async function handleHumanMessage(roomId, content, attachments, replyTo, senderWs) {
@@ -3223,6 +3231,24 @@ server.listen(PORT, () => {
   console.log(`Stoa running → http://localhost:${PORT}`);
 });
 
+function waitForRoomIdle(roomId, timeoutMs = 300000) {
+  return new Promise(resolve => {
+    if (!activeSequences.has(roomId)) return resolve();
+    const onIdle = (id) => {
+      if (id !== roomId) return;
+      process.removeListener('stoa:room_idle', onIdle);
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      process.removeListener('stoa:room_idle', onIdle);
+      console.warn(`[queue] room ${roomId} idle timeout after ${timeoutMs}ms`);
+      resolve();
+    }, timeoutMs);
+    process.on('stoa:room_idle', onIdle);
+  });
+}
+
 // ─── Slack automation listener ────────────────────────────────────────────────
 
 const _slackProcessed = new Map(); // key → expiresAt, for dedup
@@ -3297,14 +3323,23 @@ connectionManager.on('slack_event', async ({ eventType, event, webClient, connId
         .replace(/\{\{slack_channel\}\}/g, slackChannel)
         .replace(/\{\{extracted_url\}\}/g, extractedUrl);
 
-      // Send to target room (as human message to trigger agents)
-      handleHumanMessage(auto.target_room_id, prompt, null, null, null).catch(e =>
-        console.error(`[automation] room ${auto.target_room_id} trigger error:`, e.message)
+      // Queue automation — one at a time per room
+      const _roomId = auto.target_room_id;
+      const _prompt = prompt;
+      const _autoName = auto.name;
+      const _autoId = auto.id;
+      automationQueue.enqueue(_roomId, async () => {
+        await waitForRoomIdle(_roomId);
+        await handleHumanMessage(_roomId, _prompt, null, null, null);
+        await new Promise(r => setTimeout(r, 300));
+        await waitForRoomIdle(_roomId);
+      }, { automation: _autoName }).catch(e =>
+        console.error(`[automation] room ${_roomId} trigger error:`, e.message)
       );
 
       // Update run stats
-      db.prepare("UPDATE automations SET run_count=run_count+1, last_run_at=datetime('now') WHERE id=?").run(auto.id);
-      console.log(`[automation] "${auto.name}" triggered → room ${auto.target_room_id}`);
+      db.prepare("UPDATE automations SET run_count=run_count+1, last_run_at=datetime('now') WHERE id=?").run(_autoId);
+      console.log(`[automation] "${_autoName}" queued → room ${_roomId} (pending: ${automationQueue.pending(_roomId)})`);
     }
   } catch (e) {
     console.error('[automation] slack_event handler error:', e.message);

--- a/server.js
+++ b/server.js
@@ -3335,7 +3335,6 @@ connectionManager.on('slack_event', async ({ eventType, event, webClient, connId
       automationQueue.enqueue(_roomId, async () => {
         await waitForRoomIdle(_roomId);
         await handleHumanMessage(_roomId, _prompt, null, null, null);
-        await new Promise(r => setTimeout(r, 300));
         await waitForRoomIdle(_roomId);
       }, { automation: _autoName }).catch(e =>
         console.error(`[automation] room ${_roomId} trigger error:`, e.message)

--- a/server.js
+++ b/server.js
@@ -2659,60 +2659,62 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
   activeSequences.set(roomId, seq);
   let turnCount = 0;
 
-  // Immutable during sequence: prefetch once
-  const wdRow = db.prepare(
-    'SELECT w.path, w.actor_id FROM rooms r LEFT JOIN agent_workdirs w ON w.id=r.workdir_id WHERE r.id=?'
-  ).get(roomId);
-  const repliedMsg = replyTo ? db.prepare(`
-    SELECT m.content, a.name FROM messages m
-    JOIN room_participants rp ON rp.id=m.participant_id JOIN actors a ON a.id=rp.actor_id
-    WHERE m.id=?
-  `).get(replyTo) : null;
-  // Mutable during sequence: prepare once, execute per-iteration
-  const participantsStmt = db.prepare(`
-    SELECT rp.id as participant_id, a.id as actor_id, a.name, a.type
-    FROM room_participants rp JOIN actors a ON a.id=rp.actor_id WHERE rp.room_id=?
-  `);
-  const allAiStmt = db.prepare(`
-    SELECT rp.id as participant_id, a.id as actor_id, a.name, a.adapter, a.adapter_config, a.avatar_color, a.avatar_symbol, a.avatar_url
-    FROM room_participants rp JOIN actors a ON a.id=rp.actor_id
-    WHERE rp.room_id=? AND a.type='ai' AND rp.notify_on_message=1
-  `);
+  try {
+    // Immutable during sequence: prefetch once
+    const wdRow = db.prepare(
+      'SELECT w.path, w.actor_id FROM rooms r LEFT JOIN agent_workdirs w ON w.id=r.workdir_id WHERE r.id=?'
+    ).get(roomId);
+    const repliedMsg = replyTo ? db.prepare(`
+      SELECT m.content, a.name FROM messages m
+      JOIN room_participants rp ON rp.id=m.participant_id JOIN actors a ON a.id=rp.actor_id
+      WHERE m.id=?
+    `).get(replyTo) : null;
+    // Mutable during sequence: prepare once, execute per-iteration
+    const participantsStmt = db.prepare(`
+      SELECT rp.id as participant_id, a.id as actor_id, a.name, a.type
+      FROM room_participants rp JOIN actors a ON a.id=rp.actor_id WHERE rp.room_id=?
+    `);
+    const allAiStmt = db.prepare(`
+      SELECT rp.id as participant_id, a.id as actor_id, a.name, a.adapter, a.adapter_config, a.avatar_color, a.avatar_symbol, a.avatar_url
+      FROM room_participants rp JOIN actors a ON a.id=rp.actor_id
+      WHERE rp.room_id=? AND a.type='ai' AND rp.notify_on_message=1
+    `);
 
-  for (let i = 0; i < Math.min(agents.length, maxTurns); i++) {
-    if (seq.cancelled) break;
-    turnCount++;
-    const currentAgent = agents[i];
-    const prefetchedCtx = { allParticipants: participantsStmt.all(roomId), wdRow, repliedMsg };
-    await triggerAiResponse(roomId, currentAgent, content, replyTo, attachments, prefetchedCtx);
-    if (seq.cancelled) break;
+    for (let i = 0; i < Math.min(agents.length, maxTurns); i++) {
+      if (seq.cancelled) break;
+      turnCount++;
+      const currentAgent = agents[i];
+      const prefetchedCtx = { allParticipants: participantsStmt.all(roomId), wdRow, repliedMsg };
+      await triggerAiResponse(roomId, currentAgent, content, replyTo, attachments, prefetchedCtx);
+      if (seq.cancelled) break;
 
-    const lastMsg = db.prepare(`
-      SELECT m.content FROM messages m
-      JOIN room_participants rp ON rp.id=m.participant_id
-      WHERE rp.actor_id=? AND m.room_id=? AND m.state='complete'
-      ORDER BY m.id DESC LIMIT 1
-    `).get(currentAgent.actor_id, roomId);
+      const lastMsg = db.prepare(`
+        SELECT m.content FROM messages m
+        JOIN room_participants rp ON rp.id=m.participant_id
+        WHERE rp.actor_id=? AND m.room_id=? AND m.state='complete'
+        ORDER BY m.id DESC LIMIT 1
+      `).get(currentAgent.actor_id, roomId);
 
-    if (lastMsg?.content) {
-      const allAiInRoom = allAiStmt.all(roomId);
-      for (const other of allAiInRoom) {
-        if (other.actor_id !== currentAgent.actor_id && lastMsg.content.includes('@' + other.name)) {
-          const alreadyQueued = agents.slice(i + 1).some(a => a.actor_id === other.actor_id);
-          if (!alreadyQueued) agents.push(other);
+      if (lastMsg?.content) {
+        const allAiInRoom = allAiStmt.all(roomId);
+        for (const other of allAiInRoom) {
+          if (other.actor_id !== currentAgent.actor_id && lastMsg.content.includes('@' + other.name)) {
+            const alreadyQueued = agents.slice(i + 1).some(a => a.actor_id === other.actor_id);
+            if (!alreadyQueued) agents.push(other);
+          }
+        }
+
+        if (i < agents.length - 1) {
+          content = content + '\n\n' + `[${agents[i].name} sudah merespons: ${lastMsg.content}]`;
         }
       }
 
-      if (i < agents.length - 1) {
-        content = content + '\n\n' + `[${agents[i].name} sudah merespons: ${lastMsg.content}]`;
-      }
+      if (turnCount >= maxTurns) break;
     }
-
-    if (turnCount >= maxTurns) break;
+  } finally {
+    activeSequences.delete(roomId);
+    process.emit('stoa:room_idle', roomId);
   }
-
-  activeSequences.delete(roomId);
-  process.emit('stoa:room_idle', roomId);
 }
 
 async function handleHumanMessage(roomId, content, attachments, replyTo, senderWs) {

--- a/server.js
+++ b/server.js
@@ -3336,12 +3336,10 @@ connectionManager.on('slack_event', async ({ eventType, event, webClient, connId
         await waitForRoomIdle(_roomId);
         await handleHumanMessage(_roomId, _prompt, null, null, null);
         await waitForRoomIdle(_roomId);
+        db.prepare("UPDATE automations SET run_count=run_count+1, last_run_at=datetime('now') WHERE id=?").run(_autoId);
       }, { automation: _autoName }).catch(e =>
         console.error(`[automation] room ${_roomId} trigger error:`, e.message)
       );
-
-      // Update run stats
-      db.prepare("UPDATE automations SET run_count=run_count+1, last_run_at=datetime('now') WHERE id=?").run(_autoId);
       console.log(`[automation] "${_autoName}" queued → room ${_roomId} (pending: ${automationQueue.pending(_roomId)})`);
     }
   } catch (e) {

--- a/server.js
+++ b/server.js
@@ -2652,6 +2652,8 @@ function resolveAgentOrder(content, agents) {
 }
 
 const activeSequences = new Map(); // roomId → { cancelled: bool }
+const roomIdleBus = new (require('events').EventEmitter)();
+roomIdleBus.setMaxListeners(0); // unbounded — one listener per queued room
 
 async function triggerAgentsSequential(roomId, agents, content, replyTo, attachments) {
   const maxTurns = parseInt(process.env.MAX_AI_TURNS || '5');
@@ -2713,7 +2715,7 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
     }
   } finally {
     activeSequences.delete(roomId);
-    process.emit('stoa:room_idle', roomId);
+    roomIdleBus.emit('idle', roomId);
   }
 }
 
@@ -3238,16 +3240,16 @@ function waitForRoomIdle(roomId, timeoutMs = 300000) {
     if (!activeSequences.has(roomId)) return resolve();
     const onIdle = (id) => {
       if (id !== roomId) return;
-      process.removeListener('stoa:room_idle', onIdle);
+      roomIdleBus.removeListener('idle', onIdle);
       clearTimeout(timer);
       resolve();
     };
     const timer = setTimeout(() => {
-      process.removeListener('stoa:room_idle', onIdle);
+      roomIdleBus.removeListener('idle', onIdle);
       console.warn(`[queue] room ${roomId} idle timeout after ${timeoutMs}ms`);
       resolve();
     }, timeoutMs);
-    process.on('stoa:room_idle', onIdle);
+    roomIdleBus.on('idle', onIdle);
   });
 }
 


### PR DESCRIPTION
## Summary

- **queue-manager.js** (new) — generic per-key async queue with EventEmitter, sequential drain per room, error-safe with try/finally
- **server.js** — automation triggers now enqueue instead of fire-and-forget. Waits for room idle (AI done responding) before processing next trigger
- Handles compacting naturally — agent still running = room still busy = new triggers queue

## Problem

Multiple automation triggers arriving near-simultaneously for the same room would fire handleHumanMessage concurrently, causing overlapping AI responses and context chaos.

## Solution

Per-room queue with idle detection:
1. Trigger masuk → cek room busy → kalau busy, masuk antrian
2. Setelah AI selesai respond → room idle → proses trigger berikutnya
3. 5-minute timeout safety to prevent permanent queue block

## Audit findings (5 fixed across 4 audit rounds)

| Severity | Finding | Fix |
|----------|---------|-----|
| CRITICAL | emit error without listener crashes Node.js | renamed to item_error |
| HIGH | _drain no try/finally → permanent key block | added try/finally |
| HIGH | triggerAgentsSequential no try/finally → room stuck busy | added try/finally |
| MEDIUM | process.on global → MaxListenersExceededWarning | dedicated roomIdleBus |
| LOW | unnecessary 300ms delay | removed |

## Test plan

- [x] Sent 2 near-simultaneous Slack messages matching automation conditions
- [x] Verified first processed immediately (pending: 0), second queued (pending: 1)
- [x] Verified second processed after first AI response completed
- [x] Verified queue drained log after both completed
- [x] Ara confirmed sequential processing, no race condition, no dropped messages
