### PR TITLE
fix: expand ~ in workdir paths + show basename in dropdown

### DIFF
--- a/changelog/version-0-2-10.md
+++ b/changelog/version-0-2-10.md
@@ -1,0 +1,7 @@
+# v0.2.10 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- fix: set loaded=true for binary file_read so tab re-click doesn't re-fetch

--- a/changelog/version-0-2-11.md
+++ b/changelog/version-0-2-11.md
@@ -1,0 +1,7 @@
+# v0.2.11 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- fix: path.resolve inside try-catch; fallback to full path for duplicate workdir basenames

--- a/changelog/version-0-2-12.md
+++ b/changelog/version-0-2-12.md
@@ -1,0 +1,7 @@
+# v0.2.12 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- fix: clear error state on tab re-click; guard ghost-row delete against rooms

--- a/changelog/version-0-2-13.md
+++ b/changelog/version-0-2-13.md
@@ -1,0 +1,7 @@
+# v0.2.13 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- fix: image error display; wsOpenFile offline guard; skills query NULL workdir

--- a/changelog/version-0-2-14.md
+++ b/changelog/version-0-2-14.md
@@ -1,0 +1,7 @@
+# v0.2.14 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- simplify: unified error state check before IMG_EXTS; revert redundant workdir_id sentinel

--- a/changelog/version-0-2-6.md
+++ b/changelog/version-0-2-6.md
@@ -1,0 +1,8 @@
+# v0.2.6 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- show basename in workdir dropdown when no label set
+- fix: expand ~ in workdir paths so working tree shows real content

--- a/changelog/version-0-2-7.md
+++ b/changelog/version-0-2-7.md
@@ -1,0 +1,7 @@
+# v0.2.7 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- fix: re-clicking errored file tab now retries read; atomify workdir canonicalization

--- a/changelog/version-0-2-8.md
+++ b/changelog/version-0-2-8.md
@@ -1,0 +1,7 @@
+# v0.2.8 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- fix: workdir basename for windows paths; remove ghost DB row on failed create

--- a/changelog/version-0-2-9.md
+++ b/changelog/version-0-2-9.md
@@ -1,0 +1,7 @@
+# v0.2.9 — 2026-06-17
+
+🔧 Bug fixes & improvements
+
+## Changes
+
+- pre-fill new folder input with ~/ as default path

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.2.5",
+  "version": "0.2.14",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/public/js/composer/rooms-modal.js
+++ b/public/js/composer/rooms-modal.js
@@ -10,10 +10,17 @@ async function loadWorkdirsForActor(actorId) {
   sel.innerHTML = '';
   section.style.display = 'block';
   newWdRow.style.display = 'none';
+  const nameCounts = {};
+  workdirs.forEach(w => {
+    const n = w.label || w.path.split(/[/\\]/).pop() || w.path;
+    nameCounts[n] = (nameCounts[n] || 0) + 1;
+  });
   workdirs.forEach(w => {
     const opt = document.createElement('option');
     opt.value = w.id;
-    opt.textContent = (w.label || w.path) + (w.is_default ? ' (default)' : '');
+    const basename = w.label || w.path.split(/[/\\]/).pop() || w.path;
+    const wdName = nameCounts[basename] > 1 ? w.path : basename;
+    opt.textContent = wdName + (w.is_default ? ' (default)' : '');
     if (w.is_default) opt.selected = true;
     sel.appendChild(opt);
   });
@@ -23,16 +30,20 @@ async function loadWorkdirsForActor(actorId) {
   newOpt.value = '__new__';
   newOpt.textContent = '+ new folder…';
   sel.appendChild(newOpt);
+  const newWdInput = document.getElementById('new-room-new-workdir-input');
   if (workdirs.length === 0) {
     newOpt.selected = true;
     newWdRow.style.display = 'flex';
+    if (newWdInput && !newWdInput.value) newWdInput.value = '~/';
   }
 
   // Remove old listener by cloning
   const newSel = sel.cloneNode(true);
   sel.parentNode.replaceChild(newSel, sel);
   newSel.addEventListener('change', () => {
-    newWdRow.style.display = newSel.value === '__new__' ? 'flex' : 'none';
+    const showing = newSel.value === '__new__';
+    newWdRow.style.display = showing ? 'flex' : 'none';
+    if (showing && newWdInput && !newWdInput.value) newWdInput.value = '~/';
   });
 }
 

--- a/public/js/websocket.js
+++ b/public/js/websocket.js
@@ -208,15 +208,21 @@ function handleWsMessage(msg) {
   }
 
   if (msg.type === 'file_read') {
-    if (msg.error) { console.warn('[ws] file_read error:', msg.error); return; }
+    if (msg.error) {
+      console.warn('[ws] file_read error:', msg.error);
+      const f = wsOpenFiles.find(f => f.name === msg.path);
+      if (f) { f.error = msg.error; f.loaded = false; }
+      if (wsActiveView === 'file' && wsActiveFile === msg.path) wsRenderContent();
+      return;
+    }
     const panel = document.getElementById('workspace-panel');
     if (!panel.classList.contains('open')) toggleWorkspacePanel();
     if (msg.base64) {
       const ext = wsGetExt(msg.path);
       const mimeMap = { png:'image/png', jpg:'image/jpeg', jpeg:'image/jpeg', gif:'image/gif', webp:'image/webp', svg:'image/svg+xml', ico:'image/x-icon', bmp:'image/bmp' };
       const existing = wsOpenFiles.find(f => f.name === msg.path);
-      if (existing) existing.base64 = msg.base64;
-      else wsOpenFiles.push({ name: msg.path, content: '', base64: msg.base64, ext });
+      if (existing) { existing.base64 = msg.base64; existing.loaded = true; }
+      else wsOpenFiles.push({ name: msg.path, content: '', base64: msg.base64, ext, loaded: true });
       wsActiveFile = msg.path;
       wsActiveView = 'file';
       wsRenderTabs();

--- a/public/js/workspace/files.js
+++ b/public/js/workspace/files.js
@@ -42,7 +42,8 @@ function wsSetView(view) {
 function wsOpenFile(name, content) {
   const existing = wsOpenFiles.find(f => f.name === name);
   if (existing) {
-    if (content != null) { existing.content = content; existing.loaded = true; }
+    if (content != null) { existing.content = content; existing.loaded = true; existing.error = null; }
+    else if (ws) { existing.error = null; }
   } else {
     wsOpenFiles.push({ name, content: content ?? '', ext: wsGetExt(name), loaded: content != null });
   }
@@ -180,7 +181,7 @@ function wsRenderTabs() {
     const indicator = document.createElement('span');
     indicator.className = 'ws-tab-indicator';
     tab.appendChild(indicator);
-    tab.onclick = () => wsOpenFile(f.name, f.content);
+    tab.onclick = () => wsOpenFile(f.name, f.loaded ? f.content : null);
     list.appendChild(tab);
   });
 }
@@ -272,6 +273,13 @@ function wsRenderContent() {
     wsRenderToolbarActions();
 
     const IMG_EXTS = new Set(['png','jpg','jpeg','gif','webp','svg','ico','bmp']);
+    if (file.error && !file.base64) {
+      content.innerHTML = `<div class="ws-empty-state">
+        <div class="ws-empty-title">could not open file</div>
+        <div class="ws-empty-text">${wsEscHtml(file.error)}</div>
+      </div>`;
+      return;
+    }
     if (IMG_EXTS.has(ext)) {
       content.className = 'ws-scroll';
       content.style.cssText = 'flex:1;min-height:0;overflow:auto;display:flex;align-items:center;justify-content:center;padding:24px;background:color-mix(in srgb,var(--h-ink) 4%,var(--h-bg))';

--- a/server.js
+++ b/server.js
@@ -2395,6 +2395,45 @@ wss.on('connection', (ws, req) => {
     }
 
     // ── Agent proxy file responses
+    if (msg.type === 'workdir_created' && agentActorId) {
+      // Agent resolved the requested path (e.g. expanded "~") to an absolute path.
+      // Store the canonical absolute path so file ops resolve correctly.
+      if (msg.error && msg.requested) {
+        // Workdir creation failed — remove the ghost row and null out any rooms that already
+        // reference it (browser may have created a room optimistically before agent confirmed)
+        try {
+          const ghostRow = db.prepare('SELECT id FROM agent_workdirs WHERE actor_id=? AND path=?').get(agentActorId, msg.requested);
+          if (ghostRow) {
+            db.transaction(() => {
+              db.prepare('UPDATE rooms SET workdir_id=NULL WHERE workdir_id=?').run(ghostRow.id);
+              db.prepare('DELETE FROM agent_workdirs WHERE id=?').run(ghostRow.id);
+            })();
+          }
+        } catch (e) { console.warn('[workdir] could not remove ghost row:', e.message); }
+        return;
+      }
+      if (!msg.error && msg.path && msg.requested && msg.path !== msg.requested) {
+        try {
+          const requestedRow = db.prepare('SELECT id FROM agent_workdirs WHERE actor_id=? AND path=?').get(agentActorId, msg.requested);
+          if (requestedRow) {
+            const existingResolved = db.prepare('SELECT id FROM agent_workdirs WHERE actor_id=? AND path=?').get(agentActorId, msg.path);
+            if (existingResolved && existingResolved.id !== requestedRow.id) {
+              // Canonical row already exists — repoint rooms and drop the duplicate tilde row (atomic)
+              db.transaction(() => {
+                db.prepare('UPDATE rooms SET workdir_id=? WHERE workdir_id=?').run(existingResolved.id, requestedRow.id);
+                db.prepare('DELETE FROM agent_workdirs WHERE id=?').run(requestedRow.id);
+              })();
+            } else {
+              db.prepare('UPDATE agent_workdirs SET path=? WHERE id=?').run(msg.path, requestedRow.id);
+            }
+          }
+        } catch (e) {
+          console.warn('[workdir] could not canonicalize path:', e.message);
+        }
+      }
+      return;
+    }
+
     if (msg.type === 'proxy_file_list_result' && agentActorId) {
       const op = pendingFileOps.get(msg.request_id);
       if (op && op.clientWs.readyState === 1) {

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.4.44';
+const CLIENT_VERSION = '0.4.54';
 
 const WebSocket = require('ws');
 const readline = require('readline');
@@ -351,7 +351,17 @@ function connect() {
 }
 
 // ─── Agent mode ───────────────────────────────────────────────────────────────
+function expandHome(p) {
+  if (typeof p !== 'string' || !p) return p;
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/') || p.startsWith('~\\')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
 async function handleAgentMessage(msg) {
+  // Normalize tilde in workdir for every proxy/file op (handles legacy DB rows too)
+  if (msg && typeof msg.workdir === 'string') msg.workdir = expandHome(msg.workdir);
+
   if (msg.type === 'auth_error') {
     console.error(`[stoa] Auth failed: ${msg.message}. Set STOA_SECRET correctly and restart.`);
     process.exit(1);
@@ -435,13 +445,17 @@ async function handleAgentMessage(msg) {
 
   if (msg.type === 'create_workdir') {
     try {
-      fs.mkdirSync(msg.path, { recursive: true });
+      const resolved = path.resolve(expandHome(msg.path));
+      fs.mkdirSync(resolved, { recursive: true });
       // Write CLAUDE.md so Claude Code trusts this directory without interactive prompt
-      const claudeMd = path.join(msg.path, 'CLAUDE.md');
+      const claudeMd = path.join(resolved, 'CLAUDE.md');
       if (!fs.existsSync(claudeMd)) fs.writeFileSync(claudeMd, '', 'utf8');
-      console.log(`[stoa] Created workdir: ${msg.path}`);
+      console.log(`[stoa] Created workdir: ${resolved}`);
+      // Report the resolved absolute path so the server stores the canonical path (not "~/...")
+      send({ type: 'workdir_created', requested: msg.path, path: resolved });
     } catch (err) {
       console.error('[stoa] Failed to create workdir:', err.message);
+      send({ type: 'workdir_created', requested: msg.path, error: err.message });
     }
   }
 


### PR DESCRIPTION
## Summary

- **Root cause fix:** tilde `~` in workdir paths was not expanded by Node.js `fs` — agent created a literal folder named `~` instead of resolving to home directory. This caused the working tree to show only CLAUDE.md (from the wrong folder) and file reads to fail silently with an infinite spinner.
- **stoa.js:** added `expandHome()` helper, normalize `msg.workdir` at top of dispatcher, expand path in `create_workdir` and report back resolved absolute path via `workdir_created` message.
- **server.js:** handle `workdir_created` — canonicalize stored path to absolute in DB, safe against unique constraint (repoints room and removes duplicate row if canonical path already exists).
- **Frontend:** surface `file_read` errors in the panel instead of swallowing them silently; clear error state on successful read.
- **Dropdown fix:** workdir dropdown in new room modal now shows `basename(path)` as fallback when no label is set, so absolute paths no longer appear inconsistently alongside short names.

## Test plan
- [ ] Create new room with `~/...` path → folder created at correct absolute path, working tree shows real content
- [ ] Open file in working tree → opens correctly, no infinite spinner
- [ ] Open CLAUDE.md (empty file) → shows empty content, not loading spinner
- [ ] File read error → shows error message in panel instead of spinner
- [ ] Workdir dropdown in new room → all entries show short name (basename), no full paths