### PR TITLE
show hidden files in agent file tree

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.8.6",
+      "version": "0.8.7",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.4.139';
+const CLIENT_VERSION = '0.4.140';
 
 const WebSocket = require('ws');
 const readline = require('readline');
@@ -77,8 +77,8 @@ function buildFileTreeAgent(dirPath, rootPath, depth, maxDepth) {
   let entries;
   try { entries = fs.readdirSync(dirPath, { withFileTypes: true }); } catch { return []; }
   const result = [];
-  const dirs = entries.filter(e => e.isDirectory() && !TREE_IGNORE.has(e.name) && !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name));
-  const files = entries.filter(e => e.isFile() && !e.name.startsWith('.')).sort((a, b) => a.name.localeCompare(b.name));
+  const dirs = entries.filter(e => e.isDirectory() && !TREE_IGNORE.has(e.name)).sort((a, b) => a.name.localeCompare(b.name));
+  const files = entries.filter(e => e.isFile()).sort((a, b) => a.name.localeCompare(b.name));
   for (const d of dirs) {
     const children = buildFileTreeAgent(path.join(dirPath, d.name), rootPath, depth + 1, maxDepth);
     result.push({ t: 'folder', name: d.name, depth, open: depth < 1, children });


### PR DESCRIPTION
## Summary
- Remove blanket `!e.name.startsWith(".")" filter from `buildFileTreeAgent` in `stoa.js`
- `TREE_IGNORE` set already handles folders that should be hidden (`.git`, `node_modules`, `.next`, etc.)
- Aligns agent-side behavior with server-side `buildFileTree` which never had this filter

## Root cause
Agent `stoa.js:buildFileTreeAgent` filtered ALL dotfiles/dotfolders, while server `server.js:buildFileTree` only filtered via `WS_IGNORE` set. Rooms with local workdir (Mac) showed dotfiles; rooms with remote workdir (Ubuntu agent) did not.

## Test plan
- [x] 158/158 tests pass
- [ ] Verify dotfiles visible in file tree for remote agent rooms
- [ ] Verify .git, node_modules still hidden (via TREE_IGNORE)