### PR TITLE
add timestamped logging to Slack automation pipeline

### DIFF
--- a/connection-manager.js
+++ b/connection-manager.js
@@ -40,6 +40,8 @@ class SlackConnection extends EventEmitter {
       this.client.on(eventType, ({ event, ack }) => {
         ack();
         if (!event) return;
+        const ts = new Date().toISOString().replace('T', ' ').replace('Z', ' UTC');
+        console.log(`[${ts}] [slack:recv] type=${eventType} channel=${event.channel || event.item?.channel || '-'} ts=${event.ts || event.event_ts || '-'}`);
         this.emit('slack_event', { eventType, event, webClient: this.webClient, connId: this.connId });
       });
     };
@@ -48,6 +50,8 @@ class SlackConnection extends EventEmitter {
     this.client.on('app_mention', ({ event, ack }) => {
       ack();
       if (!event) return;
+      const ts = new Date().toISOString().replace('T', ' ').replace('Z', ' UTC');
+      console.log(`[${ts}] [slack:recv] type=mention channel=${event.channel || '-'} ts=${event.ts || '-'}`);
       this.emit('slack_event', { eventType: 'mention', event, webClient: this.webClient, connId: this.connId });
     });
     fwd('message');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -4359,6 +4359,11 @@ connectionManager.on('slack_event', async ({ eventType, event, webClient, connId
 
       if (!allMatch) continue;
 
+      {
+        const ts = new Date().toISOString().replace('T', ' ').replace('Z', ' UTC');
+        console.log(`[${ts}] [automation:${auto.name}] condition_matched - event=${eventType} channel=${channelId} slack_ts=${event.ts || event.event_ts || '-'}`);
+      }
+
       const prompt = auto.prompt_template
         .replace(/\{\{slack_message_text\}\}/g, text)
         .replace(/\{\{slack_message_link\}\}/g, messageLink)
@@ -4372,9 +4377,25 @@ connectionManager.on('slack_event', async ({ eventType, event, webClient, connId
       const _prompt = prompt;
       const _autoName = auto.name;
       const _autoId = auto.id;
+      {
+        const ts = new Date().toISOString().replace('T', ' ').replace('Z', ' UTC');
+        console.log(`[${ts}] [automation:${_autoName}] enqueued - room=${_roomId} pending=${automationQueue.pending(_roomId)}`);
+      }
       automationQueue.enqueue(_roomId, async () => {
+        {
+          const ts = new Date().toISOString().replace('T', ' ').replace('Z', ' UTC');
+          console.log(`[${ts}] [automation:${_autoName}] dequeued - room=${_roomId} waiting_idle`);
+        }
         await waitForRoomIdle(_roomId);
+        {
+          const ts = new Date().toISOString().replace('T', ' ').replace('Z', ' UTC');
+          console.log(`[${ts}] [automation:${_autoName}] sending_message - room=${_roomId}`);
+        }
         await handleHumanMessage(_roomId, _prompt, null, null, null);
+        {
+          const ts = new Date().toISOString().replace('T', ' ').replace('Z', ' UTC');
+          console.log(`[${ts}] [automation:${_autoName}] message_sent - room=${_roomId}`);
+        }
         await waitForRoomIdle(_roomId);
         db.prepare("UPDATE automations SET run_count=run_count+1, last_run_at=datetime('now') WHERE id=?").run(_autoId);
       }, { automation: _autoName }).catch(e =>


### PR DESCRIPTION
## Summary
- Add precise UTC timestamps at each stage of the Slack → automation → room pipeline
- Enables diagnosis of where delay occurs (Slack delivery vs Stoa processing)

## Log points added

1. **connection-manager.js** — `[slack:recv]` when Slack Socket Mode event arrives
2. **server.js** — `[automation:NAME] condition_matched` when filter conditions pass
3. **server.js** — `[automation:NAME] enqueued` when task added to room queue
4. **server.js** — `[automation:NAME] dequeued` + `waiting_idle` when task starts executing
5. **server.js** — `[automation:NAME] sending_message` just before handleHumanMessage
6. **server.js** — `[automation:NAME] message_sent` after handleHumanMessage completes

## Format
```
[2026-07-01 02:44:12.345 UTC] [slack:recv] type=message channel=C0B6Q16RNTH ts=1782874260.123
[2026-07-01 02:44:12.350 UTC] [automation:war-mbg] condition_matched - event=message channel=C0B6Q16RNTH slack_ts=1782874260.123
[2026-07-01 02:44:12.351 UTC] [automation:war-mbg] enqueued - room=2282 pending=0
[2026-07-01 02:44:12.352 UTC] [automation:war-mbg] dequeued - room=2282 waiting_idle
[2026-07-01 02:44:12.353 UTC] [automation:war-mbg] sending_message - room=2282
[2026-07-01 02:51:03.000 UTC] [automation:war-mbg] message_sent - room=2282
```

## Context
Investigation of war-mbg automation 7-minute delay on 2026-07-01 02:44→02:51 UTC.