### PR TITLE
inject STOA_ROOM_ID to agent env and add proactive message docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "stoa",
-  "version": "0.8.11",
+
+  "version": "0.9.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/stoa.js
+++ b/stoa.js
@@ -819,15 +819,18 @@ async function processTrigger(msg) {
       try {
         fs.mkdirSync(msg.workdir, { recursive: true });
         const claudeMd = path.join(msg.workdir, 'CLAUDE.md');
-        if (!fs.existsSync(claudeMd)) fs.writeFileSync(claudeMd, '', 'utf8');
+        if (!fs.existsSync(claudeMd)) {
+          const proactiveInstructions = '# Stoa Agent Context\n\n## Proactive Message\n\nKamu bisa mengirim pesan ke room Stoa secara proaktif tanpa menunggu user bertanya.\nGunakan ini saat background task selesai atau ada info penting.\n\n```bash\nBASE_URL=$(echo "$STOA_URL" | sed "s|^ws://|http://|;s|^wss://|https://|")\ncurl -s -X POST "$BASE_URL/api/rooms/$STOA_ROOM_ID/message" \\\\\n  -H "Content-Type: application/json" \\\\\n  -H "x-agent-id: $STOA_ACTOR_ID" \\\\\n  -H "x-agent-secret: $STOA_SECRET" \\\\\n  -d \\\'{"content": "Pesan kamu di sini"}\\\'\n```\n\n`$STOA_URL`, `$STOA_ACTOR_ID`, `$STOA_SECRET`, dan `$STOA_ROOM_ID` tersedia sebagai env var.';
+          fs.writeFileSync(claudeMd, proactiveInstructions, 'utf8');
+        }
       } catch {}
     }
 
     const apiKeys = msg.api_keys || (msg.api_key ? [msg.api_key] : []);
-    const platformEnv = {};
+    const platformEnv = { STOA_ROOM_ID: String(room_id) };
     if (msg.base_url) platformEnv.ANTHROPIC_BASE_URL = msg.base_url;
     if (apiKeys[0]) platformEnv.ANTHROPIC_AUTH_TOKEN = apiKeys[0];
-    const envToUse = Object.keys(platformEnv).length ? platformEnv : null;
+    const envToUse = platformEnv;
 
     let session = getSession(targetDir, envToUse);
     const needsResume = rid && session.resumeId !== rid;


### PR DESCRIPTION
Agents can now send proactive messages to Stoa rooms using env vars that are already available.

## Changes

**stoa.js** (CLIENT_VERSION 0.4.141 → 0.4.142):

1. **Inject  per trigger** —  now always includes , so Claude CLI inherits the current room ID as an env var for each trigger.

2. **Write proactive message docs to workdir CLAUDE.md** — When a workdir CLAUDE.md is first created, it now contains the curl command and explanation (using , , ,  env vars — no hardcoded localhost).

## How agents send proactive messages

Not found

## Works for new installs

- Install script already passes , ,  to agent env
-  is now injected per trigger from stoa.js (platform file)
- New workdirs get the curl docs automatically in CLAUDE.md

## Note

Existing agents need to pull the updated stoa.js and restart to get STOA_ROOM_ID injection and the new CLAUDE.md docs.