### PR TITLE
fix slack message link workspace name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -4348,7 +4348,7 @@ connectionManager.on('slack_event', async ({ eventType, event, webClient, connId
     const text = isReaction ? (event.reaction || '') : (event.text || '');
     const userId = event.user || '';
     const channelId = isReaction ? (event.item?.channel || '') : (event.channel || '');
-    const workspace = getSetting('slack_workspace_name') || '';
+    const workspace = connectionManager.getSlackConnection(connId)?.workspaceName || getSetting('slack_workspace_name') || '';
     const tsForLink = isReaction ? (event.item?.ts || '') : (event.ts || '');
     const messageLink = tsForLink
       ? `https://${workspace}.slack.com/archives/${channelId}/p${tsForLink.replace('.', '')}`


### PR DESCRIPTION
Slack message link di automation menghasilkan URL invalid (https://.slack.com/...) karena workspace name dibaca dari legacy setting yang tidak pernah di-write oleh connection flow baru. Fix: baca dari connectionManager.getSlackConnection(connId).workspaceName, fallback ke legacy setting.