### PR TITLE
fix: slack message link uses workspace display name instead of domain

### DIFF
--- a/connection-manager.js
+++ b/connection-manager.js
@@ -13,6 +13,7 @@ class SlackConnection extends EventEmitter {
     this.webClient = null;
     this.running = false;
     this.workspaceName = null;
+    this.workspaceDomain = null;
     this.botName = null;
   }
 
@@ -28,6 +29,9 @@ class SlackConnection extends EventEmitter {
     try {
       const info = await this.webClient.auth.test();
       this.workspaceName = info.team;
+      // info.team is the display name (may contain spaces, e.g. "Qiscus Tech") —
+      // unusable in URLs. info.url carries the real subdomain (https://qiscustech.slack.com/).
+      try { this.workspaceDomain = new URL(info.url).hostname.split('.')[0]; } catch { this.workspaceDomain = null; }
       this.botName = tokenType === 'bot' ? ('@' + info.user) : info.user;
     } catch (e) {
       console.error(`[conn:${this.connId}] auth.test failed:`, e.message);
@@ -85,6 +89,7 @@ class SlackConnection extends EventEmitter {
     this.webClient = null;
     this.running = false;
     this.workspaceName = null;
+    this.workspaceDomain = null;
     this.botName = null;
     console.log(`[conn:${this.connId}] stopped`);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -4348,7 +4348,7 @@ connectionManager.on('slack_event', async ({ eventType, event, webClient, connId
     const text = isReaction ? (event.reaction || '') : (event.text || '');
     const userId = event.user || '';
     const channelId = isReaction ? (event.item?.channel || '') : (event.channel || '');
-    const workspace = connectionManager.getSlackConnection(connId)?.workspaceName || getSetting('slack_workspace_name') || '';
+    const workspace = connectionManager.getSlackConnection(connId)?.workspaceDomain || getSetting('slack_workspace_name') || '';
     const tsForLink = isReaction ? (event.item?.ts || '') : (event.ts || '');
     const messageLink = tsForLink
       ? `https://${workspace}.slack.com/archives/${channelId}/p${tsForLink.replace('.', '')}`


### PR DESCRIPTION
## Problem

Message links produced by Slack automations are broken when the workspace display name contains spaces. Example: workspace `qiscustech` has display name **Qiscus Tech**, so links were generated as:

```
https://Qiscus Tech.slack.com/archives/C05K0BNTVU6/p1786540672307649
```

The space splits the URL when rendered in chat, making the link unusable.

## Root Cause

PR #42 (`4f5e053`) switched the link's workspace source to `connectionManager.getSlackConnection(connId)?.workspaceName`, which is populated from `auth.test().team` — the workspace **display name**, not the URL subdomain.

## Fix

- `connection-manager.js`: add `workspaceDomain`, parsed from `auth.test().url` (e.g. `https://qiscustech.slack.com/` → `qiscustech`). Falls back to `null` safely if `url` is missing; cleared on `stop()`.
- `server.js`: message link now uses `workspaceDomain`, keeping the existing fallback to the `slack_workspace_name` setting. `workspaceName` is still used for UI display.

## Testing

- `node --check` passes on both files
- Subdomain parsing verified for standard (`qiscustech.slack.com`) and enterprise (`qiscustech.enterprise.slack.com`) URL shapes, plus null-safety when `url` is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)