### PR TITLE
R19: thinking-signature management — 3-layer defense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ connector-media/
 *.sqlite-shm
 *.sqlite-wal
 .stoa-attachments/
+dist/

--- a/build/build.js
+++ b/build/build.js
@@ -45,8 +45,14 @@ fs.writeFileSync(path.join(dist, '_app.js'), jsConcat);
 execSync(`npx esbuild public/dist/_app.js --bundle --minify --outfile=public/dist/stoa.min.js`, { cwd: root, stdio: 'inherit' });
 fs.unlinkSync(path.join(dist, '_app.js'));
 
+// ── Agent bundle: stoa.js + lib/* → dist/stoa.js ──
+const agentDist = path.join(root, 'dist');
+if (!fs.existsSync(agentDist)) fs.mkdirSync(agentDist, { recursive: true });
+execSync(`npx esbuild stoa.js --bundle --platform=node --target=node18 --external:ws --external:./claude-session --outfile=dist/stoa.js`, { cwd: root, stdio: 'inherit' });
+
 // ── Summary ──
 const size = (f) => (fs.statSync(f).size / 1024).toFixed(1) + 'KB';
 console.log(`\n✓ Build complete`);
 console.log(`  vendor/  — marked ${size(path.join(vendor, 'marked.min.js'))}, purify ${size(path.join(vendor, 'purify.min.js'))}, hljs ${size(path.join(vendor, 'highlight.min.js'))}, codemirror ${size(path.join(vendor, 'codemirror.bundle.js'))}`);
 console.log(`  dist/    — stoa.min.css ${size(path.join(dist, 'stoa.min.css'))}, stoa.min.js ${size(path.join(dist, 'stoa.min.js'))}`);
+console.log(`  agent/   — dist/stoa.js ${size(path.join(agentDist, 'stoa.js'))}`);

--- a/lib/thinking-sanitizer.js
+++ b/lib/thinking-sanitizer.js
@@ -31,6 +31,8 @@ function matchThinkingBlock(b, { stripAll = false } = {}) {
 function replaceThinkingBlock(b, { stripAll = false } = {}) {
   if (THINKING_TYPES.has(b.type)) {
     if (stripAll) return null;
+    const unsigned = (b.type === 'thinking' && !b.signature) || (b.type === 'redacted_thinking' && !b.data);
+    if (unsigned) return null;
     if (b.cache_control) {
       const { cache_control, ...rest } = b;
       return rest;

--- a/lib/thinking-sanitizer.js
+++ b/lib/thinking-sanitizer.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const THINKING_TYPES = new Set(['thinking', 'redacted_thinking']);
+
+const THINKING_MARKER_RE = /^\s*(?:\[thinking\]\s*)+/;
+
+function stripLeadingThinkingMarker(text) {
+  return typeof text === 'string' ? text.replace(THINKING_MARKER_RE, '') : text;
+}
+
+function isThinkingSignatureError(text = '') {
+  if (!text || text.length > 600) return false;
+  const lower = text.toLowerCase();
+  return lower.includes('thinking')
+    && (lower.includes('signature') || lower.includes('cannot be modified') || lower.includes('must remain as they were'));
+}
+
+function matchThinkingBlock(b, { stripAll = false } = {}) {
+  if (!b || typeof b !== 'object') return false;
+  if (THINKING_TYPES.has(b.type)) {
+    if (stripAll) return true;
+    if (b.type === 'thinking' && !b.signature) return true;
+    if (b.type === 'redacted_thinking' && !b.data) return true;
+    if (b.cache_control) return true;
+    return false;
+  }
+  if (b.type === 'text' && typeof b.text === 'string' && THINKING_MARKER_RE.test(b.text)) return true;
+  return false;
+}
+
+function replaceThinkingBlock(b, { stripAll = false } = {}) {
+  if (THINKING_TYPES.has(b.type)) {
+    if (stripAll) return null;
+    if (b.cache_control) {
+      const { cache_control, ...rest } = b;
+      return rest;
+    }
+    return null;
+  }
+  const cleaned = stripLeadingThinkingMarker(b.text);
+  return cleaned ? { ...b, text: cleaned } : null;
+}
+
+module.exports = {
+  THINKING_TYPES,
+  THINKING_MARKER_RE,
+  stripLeadingThinkingMarker,
+  isThinkingSignatureError,
+  matchThinkingBlock,
+  replaceThinkingBlock,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -40,14 +40,37 @@ const EXPECTED_CLIENT_VERSION = (() => {
   } catch { return null; }
 })();
 
-// Hash of stoa.js at server startup — used as the "safe" baseline for the monotonic
-// downgrade guard in the manifest endpoint. If someone edits stoa.js to a lower version
-// while the server is running, clients must not auto-download it (they'd restart into a
-// version older than EXPECTED_CLIENT_VERSION and get stuck in a force_update loop).
+// Build agent bundle: stoa.js + lib/* → dist/stoa.js (single file for agent auto-update).
+// esbuild is fast (~50ms); rebuild on every startup ensures bundle is always fresh.
+const AGENT_BUNDLE_PATH = path.join(__dirname, 'dist', 'stoa.js');
+(() => {
+  try {
+    const distDir = path.join(__dirname, 'dist');
+    if (!fs.existsSync(distDir)) fs.mkdirSync(distDir);
+    require('esbuild').buildSync({
+      entryPoints: [path.join(__dirname, 'stoa.js')],
+      bundle: true,
+      platform: 'node',
+      target: 'node18',
+      external: ['ws', './claude-session'],
+      outfile: AGENT_BUNDLE_PATH,
+    });
+    console.log('[build] Agent bundle ready');
+  } catch (e) {
+    console.error('[build] Agent bundle failed, serving source:', e.message);
+  }
+})();
+
+// Hash of the agent bundle (or source stoa.js fallback) at startup — used as the "safe"
+// baseline for the monotonic downgrade guard in the manifest endpoint.
+function clientFilePath(name) {
+  if (name === 'stoa.js' && fs.existsSync(AGENT_BUNDLE_PATH)) return AGENT_BUNDLE_PATH;
+  return path.join(__dirname, name);
+}
+
 const SAFE_CLIENT_HASH = (() => {
   try {
-    const fp = path.join(__dirname, 'stoa.js');
-    return crypto.createHash('sha256').update(fs.readFileSync(fp)).digest('hex').slice(0, 12);
+    return crypto.createHash('sha256').update(fs.readFileSync(clientFilePath('stoa.js'))).digest('hex').slice(0, 12);
   } catch { return null; }
 })();
 
@@ -486,7 +509,7 @@ setInterval(() => {
 }, 60_000);
 
 function clientFileHash(name) {
-  const fp = path.join(__dirname, name);
+  const fp = clientFilePath(name);
   if (!fs.existsSync(fp)) return null;
   return crypto.createHash('sha256').update(fs.readFileSync(fp)).digest('hex').slice(0, 12);
 }
@@ -2391,7 +2414,7 @@ const server = http.createServer(async (req, res) => {
       // client to restart with client_version < expected indefinitely).
       if (name === 'stoa.js' && SAFE_CLIENT_HASH && EXPECTED_CLIENT_VERSION && hash !== SAFE_CLIENT_HASH) {
         try {
-          const diskSrc = fs.readFileSync(path.join(__dirname, name), 'utf8');
+          const diskSrc = fs.readFileSync(clientFilePath(name), 'utf8');
           const m = diskSrc.match(/^const CLIENT_VERSION\s*=\s*'([^']+)'/m);
           const diskVer = m ? m[1] : null;
           if (diskVer && diskVer.localeCompare(EXPECTED_CLIENT_VERSION, undefined, { numeric: true }) < 0) {
@@ -2408,7 +2431,7 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && url.pathname.startsWith('/api/client/file/')) {
     const name = path.basename(url.pathname.slice('/api/client/file/'.length));
     if (!CLIENT_FILES.has(name)) { res.writeHead(404); return res.end('Not found'); }
-    const fp = path.join(__dirname, name);
+    const fp = clientFilePath(name);
     if (!fs.existsSync(fp)) { res.writeHead(404); return res.end('Not found'); }
     res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
     return res.end(fs.readFileSync(fp));

--- a/server.js
+++ b/server.js
@@ -2415,7 +2415,7 @@ const server = http.createServer(async (req, res) => {
       if (name === 'stoa.js' && SAFE_CLIENT_HASH && EXPECTED_CLIENT_VERSION && hash !== SAFE_CLIENT_HASH) {
         try {
           const diskSrc = fs.readFileSync(clientFilePath(name), 'utf8');
-          const m = diskSrc.match(/^const CLIENT_VERSION\s*=\s*'([^']+)'/m);
+          const m = diskSrc.match(/^(?:const|var)\s+CLIENT_VERSION\s*=\s*['"]([^'"]+)['"]/m);
           const diskVer = m ? m[1] : null;
           if (diskVer && diskVer.localeCompare(EXPECTED_CLIENT_VERSION, undefined, { numeric: true }) < 0) {
             console.warn(`[update-guard] stoa.js on disk (v${diskVer}) < expected (v${EXPECTED_CLIENT_VERSION}) — suppressing manifest to prevent downgrade loop`);

--- a/server.js
+++ b/server.js
@@ -43,6 +43,7 @@ const EXPECTED_CLIENT_VERSION = (() => {
 // Build agent bundle: stoa.js + lib/* → dist/stoa.js (single file for agent auto-update).
 // esbuild is fast (~50ms); rebuild on every startup ensures bundle is always fresh.
 const AGENT_BUNDLE_PATH = path.join(__dirname, 'dist', 'stoa.js');
+let agentBundleReady = false;
 (() => {
   try {
     const distDir = path.join(__dirname, 'dist');
@@ -55,9 +56,10 @@ const AGENT_BUNDLE_PATH = path.join(__dirname, 'dist', 'stoa.js');
       external: ['ws', './claude-session'],
       outfile: AGENT_BUNDLE_PATH,
     });
+    agentBundleReady = true;
     console.log('[build] Agent bundle ready');
   } catch (e) {
-    console.error('[build] Agent bundle failed, serving source:', e.message);
+    console.error('[build] Agent bundle FAILED — agent updates will be blocked until resolved:', e.message);
   }
 })();
 
@@ -2405,6 +2407,7 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && url.pathname === '/api/client/manifest') {
     const files = {};
     for (const name of CLIENT_FILES) {
+      if (name === 'stoa.js' && !agentBundleReady) continue;
       let hash = clientFileHash(name);
       if (!hash) continue;
       // Monotonic downgrade guard: if stoa.js on disk has changed from startup and is now
@@ -2431,6 +2434,10 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && url.pathname.startsWith('/api/client/file/')) {
     const name = path.basename(url.pathname.slice('/api/client/file/'.length));
     if (!CLIENT_FILES.has(name)) { res.writeHead(404); return res.end('Not found'); }
+    if (name === 'stoa.js' && !agentBundleReady) {
+      console.error('[update] Blocked serving unbundled stoa.js — esbuild build failed at startup');
+      res.writeHead(503); return res.end('Agent bundle not available');
+    }
     const fp = clientFilePath(name);
     if (!fs.existsSync(fp)) { res.writeHead(404); return res.end('Not found'); }
     res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.4.176';
+const CLIENT_VERSION = '0.4.177';
 
 const WebSocket = require('ws');
 const readline = require('readline');
@@ -14,47 +14,7 @@ const os = require('os');
 const { spawnSync } = require('child_process');
 
 const { ClaudeSession } = require('./claude-session');
-
-// ─── Thinking Sanitizer (inlined) ────────────────────────────────────────────
-const THINKING_TYPES = new Set(['thinking', 'redacted_thinking']);
-const THINKING_MARKER_RE = /^\s*(?:\[thinking\]\s*)+/;
-
-function stripLeadingThinkingMarker(text) {
-  return typeof text === 'string' ? text.replace(THINKING_MARKER_RE, '') : text;
-}
-
-function isThinkingSignatureError(text = '') {
-  if (!text || text.length > 600) return false;
-  const lower = text.toLowerCase();
-  return lower.includes('thinking')
-    && (lower.includes('signature') || lower.includes('cannot be modified') || lower.includes('must remain as they were'));
-}
-
-function matchThinkingBlock(b, { stripAll = false } = {}) {
-  if (!b || typeof b !== 'object') return false;
-  if (THINKING_TYPES.has(b.type)) {
-    if (stripAll) return true;
-    if (b.type === 'thinking' && !b.signature) return true;
-    if (b.type === 'redacted_thinking' && !b.data) return true;
-    if (b.cache_control) return true;
-    return false;
-  }
-  if (b.type === 'text' && typeof b.text === 'string' && THINKING_MARKER_RE.test(b.text)) return true;
-  return false;
-}
-
-function replaceThinkingBlock(b, { stripAll = false } = {}) {
-  if (THINKING_TYPES.has(b.type)) {
-    if (stripAll) return null;
-    if (b.cache_control) {
-      const { cache_control, ...rest } = b;
-      return rest;
-    }
-    return null;
-  }
-  const cleaned = stripLeadingThinkingMarker(b.text);
-  return cleaned ? { ...b, text: cleaned } : null;
-}
+const { stripLeadingThinkingMarker, isThinkingSignatureError, matchThinkingBlock, replaceThinkingBlock, THINKING_MARKER_RE } = require('./lib/thinking-sanitizer');
 
 let STOA_URL      = process.env.STOA_URL    || 'ws://localhost:3001';
 const ACTOR_ID    = parseInt(process.env.STOA_ACTOR_ID || '1');

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.4.175';
+const CLIENT_VERSION = '0.4.176';
 
 const WebSocket = require('ws');
 const readline = require('readline');
@@ -14,7 +14,47 @@ const os = require('os');
 const { spawnSync } = require('child_process');
 
 const { ClaudeSession } = require('./claude-session');
-const { stripLeadingThinkingMarker, isThinkingSignatureError, matchThinkingBlock, replaceThinkingBlock, THINKING_MARKER_RE } = require('./lib/thinking-sanitizer');
+
+// ─── Thinking Sanitizer (inlined) ────────────────────────────────────────────
+const THINKING_TYPES = new Set(['thinking', 'redacted_thinking']);
+const THINKING_MARKER_RE = /^\s*(?:\[thinking\]\s*)+/;
+
+function stripLeadingThinkingMarker(text) {
+  return typeof text === 'string' ? text.replace(THINKING_MARKER_RE, '') : text;
+}
+
+function isThinkingSignatureError(text = '') {
+  if (!text || text.length > 600) return false;
+  const lower = text.toLowerCase();
+  return lower.includes('thinking')
+    && (lower.includes('signature') || lower.includes('cannot be modified') || lower.includes('must remain as they were'));
+}
+
+function matchThinkingBlock(b, { stripAll = false } = {}) {
+  if (!b || typeof b !== 'object') return false;
+  if (THINKING_TYPES.has(b.type)) {
+    if (stripAll) return true;
+    if (b.type === 'thinking' && !b.signature) return true;
+    if (b.type === 'redacted_thinking' && !b.data) return true;
+    if (b.cache_control) return true;
+    return false;
+  }
+  if (b.type === 'text' && typeof b.text === 'string' && THINKING_MARKER_RE.test(b.text)) return true;
+  return false;
+}
+
+function replaceThinkingBlock(b, { stripAll = false } = {}) {
+  if (THINKING_TYPES.has(b.type)) {
+    if (stripAll) return null;
+    if (b.cache_control) {
+      const { cache_control, ...rest } = b;
+      return rest;
+    }
+    return null;
+  }
+  const cleaned = stripLeadingThinkingMarker(b.text);
+  return cleaned ? { ...b, text: cleaned } : null;
+}
 
 let STOA_URL      = process.env.STOA_URL    || 'ws://localhost:3001';
 const ACTOR_ID    = parseInt(process.env.STOA_ACTOR_ID || '1');

--- a/stoa.js
+++ b/stoa.js
@@ -14,6 +14,7 @@ const os = require('os');
 const { spawnSync } = require('child_process');
 
 const { ClaudeSession } = require('./claude-session');
+const { stripLeadingThinkingMarker, isThinkingSignatureError, matchThinkingBlock, replaceThinkingBlock, THINKING_MARKER_RE } = require('./lib/thinking-sanitizer');
 
 let STOA_URL      = process.env.STOA_URL    || 'ws://localhost:3001';
 const ACTOR_ID    = parseInt(process.env.STOA_ACTOR_ID || '1');
@@ -218,15 +219,6 @@ function stripBlocksFromEntry(obj, matchFn, makeReplacement) {
   return stripped;
 }
 
-// Strip the literal "[thinking]" marker from the start of a string (one or more, with surrounding
-// whitespace). Older Stoa versions replaced unsigned thinking blocks with a {type:'text',
-// text:'[thinking]'} placeholder; weaker non-Anthropic models then few-shot-mimic that pattern and
-// prefix their own replies with "[thinking]". Used both on live output and on the stored history.
-const THINKING_MARKER_RE = /^\s*(?:\[thinking\]\s*)+/;
-function stripLeadingThinkingMarker(text) {
-  return typeof text === 'string' ? text.replace(THINKING_MARKER_RE, '') : text;
-}
-
 // Shared async scaffold: rewrite a session jsonl, replacing blocks that match. `needles` are raw
 // substrings used as a cheap early-exit (whole file, then per-line) before JSON.parse. Async fs
 // (not readFileSync) so it never blocks the event loop even when called inline before a resume.
@@ -267,25 +259,41 @@ function stripSessionImages(workdir, sessionId) {
     'stripped image data');
 }
 
-// Sanitize thinking residue from the session file before a resume, in one pass:
-//   1. Unsigned thinking blocks (ollama/qwen/nemotron via proxy emit `thinking` with empty/missing
-//      `signature`). On the next Claude resume the CLI replays history to api.anthropic.com, which
-//      rejects them with 400 "Invalid `signature` in `thinking` block". Remove the block entirely.
-//   2. Leaked "[thinking]" text markers — leftover {type:'text', text:'[thinking]'} placeholders
-//      written by older Stoa versions, plus replies where a model already mimicked the pattern and
-//      glued "[thinking]" onto the front of its text. Strip the leading marker (drop the block if
-//      nothing else remains) so the pattern stops being reinforced into the model's few-shot context.
-function sanitizeThinking(workdir, sessionId) {
+function sanitizeThinking(workdir, sessionId, opts = {}) {
+  const { thirdParty = false, aggressive = false } = opts;
+  const stripAll = thirdParty || aggressive;
+  const blockOpts = { stripAll };
   return sanitizeSession(workdir, sessionId,
-    ['"type":"thinking"', '"type": "thinking"', '[thinking]'],
-    b => (b.type === 'thinking' && !b.signature)
-      || (b.type === 'text' && typeof b.text === 'string' && THINKING_MARKER_RE.test(b.text)),
-    b => {
-      if (b.type === 'thinking') return null;
-      const cleaned = stripLeadingThinkingMarker(b.text);
-      return cleaned ? { ...b, text: cleaned } : null;
-    },
-    'sanitized thinking residue');
+    ['"type":"thinking"', '"type": "thinking"', '"type":"redacted_thinking"', '"type": "redacted_thinking"', '[thinking]'],
+    b => matchThinkingBlock(b, blockOpts),
+    b => replaceThinkingBlock(b, blockOpts),
+    stripAll ? 'stripped all thinking (third-party/recovery)' : 'sanitized thinking residue');
+}
+
+async function backupSessionFile(workdir, sessionId) {
+  const filePath = sessionFilePath(workdir, sessionId);
+  if (!filePath) return null;
+  const backupPath = filePath + '.sig-bak';
+  try {
+    await fs.promises.copyFile(filePath, backupPath);
+    console.log(`[stoa] backed up session ${sessionId.slice(0, 8)}... → .sig-bak`);
+    return backupPath;
+  } catch (err) {
+    console.error(`[stoa] backup error: ${err.message}`);
+    return null;
+  }
+}
+
+async function prepareResume({ targetDir, rid, targetModel, toolsSupported, env, sessionKey, thirdParty = false, aggressive = false }) {
+  if (rid && !compactsInFlight.has(targetDir)) {
+    await sanitizeThinking(targetDir, rid, { thirdParty, aggressive });
+  }
+  const flags = rid ? ['--resume', rid] : [];
+  if (targetModel) flags.push('--model', targetModel);
+  if (toolsSupported === false) flags.push('--tools', '');
+  const session = new ClaudeSession({ workDir: targetDir, flags, resumeId: rid || null, env });
+  sessionPool.set(sessionKey, session);
+  return session;
 }
 
 function getSession(workdir, roomId, env, subAgentId) {
@@ -914,20 +922,14 @@ async function processTrigger(msg) {
 
     if (needsResume || needsFreshSession || needsModelChange || needsEnvChange) {
       session.shutdown();
-      // Sanitize the session file before the new CLI process reads it on --resume, so unsigned
-      // thinking blocks left by non-Anthropic models don't break the next Claude run.
-      if (rid && !compactsInFlight.has(targetDir)) await sanitizeThinking(targetDir, rid);
-      const flags = rid ? ['--resume', rid] : [];
-      if (targetModel) flags.push('--model', targetModel);
-      if (msg.tools_supported === false) flags.push('--tools', '');
-      session = new ClaudeSession({ workDir: targetDir, flags, resumeId: rid || null, env: envToUse });
-      sessionPool.set(sessionKey, session);
+      session = await prepareResume({ targetDir, rid, targetModel, toolsSupported: msg.tools_supported, env: envToUse, sessionKey, thirdParty: !!msg.base_url });
       console.log(`[stoa] Session restarted: workdir=${targetDir} room=${room_id}${rid ? ' resume=' + rid.slice(0, 8) + '...' : ' (fresh)'}${targetModel ? ' model=' + targetModel : ''}${msg.base_url ? ' base_url=' + msg.base_url : ''}${msg.tools_supported === false ? ' tools=disabled' : ''}`);
     }
     activeTriggers.set(message_id, { workdir: targetDir, session });
     let fullContent = '';
     let lastActivity = Date.now();
     let abortReason = null;
+    let thinkingSigRetried = false;
     statusHandler = status => {
       lastActivity = Date.now();
       send({ type: 'agent_system_event', room_id, message_id, status });
@@ -986,12 +988,7 @@ async function processTrigger(msg) {
           send({ type: 'agent_stream_reset', room_id, message_id });
           fullContent = '';
           session.shutdown();
-          if (rid && !compactsInFlight.has(targetDir)) await sanitizeThinking(targetDir, rid);
-          const flags = rid ? ['--resume', rid] : [];
-          if (targetModel) flags.push('--model', targetModel);
-          if (msg.tools_supported === false) flags.push('--tools', '');
-          session = new ClaudeSession({ workDir: targetDir, flags, resumeId: rid || null, env: envToUse });
-          sessionPool.set(sessionKey, session);
+          session = await prepareResume({ targetDir, rid, targetModel, toolsSupported: msg.tools_supported, env: envToUse, sessionKey, thirdParty: !!msg.base_url });
           activeTriggers.set(message_id, { workdir: targetDir, session });
           sessionRef = session;
           session.on('status', statusHandler);
@@ -1012,12 +1009,7 @@ async function processTrigger(msg) {
           console.log(`[stoa] API key #1 failed (${retryErr.message}), rotating to key #${ki + 1}...`);
           const rotatedEnv = { ...platformEnv, ANTHROPIC_AUTH_TOKEN: apiKeys[ki] };
           session.shutdown();
-          if (rid && !compactsInFlight.has(targetDir)) await sanitizeThinking(targetDir, rid);
-          const flags = rid ? ['--resume', rid] : [];
-          if (targetModel) flags.push('--model', targetModel);
-          if (msg.tools_supported === false) flags.push('--tools', '');
-          session = new ClaudeSession({ workDir: targetDir, flags, resumeId: rid || null, env: rotatedEnv });
-          sessionPool.set(sessionKey, session);
+          session = await prepareResume({ targetDir, rid, targetModel, toolsSupported: msg.tools_supported, env: rotatedEnv, sessionKey, thirdParty: !!msg.base_url });
           activeTriggers.set(message_id, { workdir: targetDir, session });
           sessionRef = session;
           session.on('status', statusHandler);
@@ -1051,6 +1043,19 @@ async function processTrigger(msg) {
         activeTriggers.set(message_id, { workdir: targetDir, session });
         lastActivity = Date.now();
         result = await session.send(sendOpts);
+      } else if (isThinkingSignatureError(retryErr.message) && !fullContent && !thinkingSigRetried) {
+        thinkingSigRetried = true;
+        console.log(`[stoa] thinking-signature 400 detected (exception): ${retryErr.message.slice(0, 120)}`);
+        send({ type: 'agent_stream_reset', room_id, message_id });
+        fullContent = '';
+        session.shutdown();
+        await backupSessionFile(targetDir, rid);
+        session = await prepareResume({ targetDir, rid, targetModel, toolsSupported: msg.tools_supported, env: envToUse, sessionKey, aggressive: true });
+        activeTriggers.set(message_id, { workdir: targetDir, session });
+        sessionRef = session;
+        session.on('status', statusHandler);
+        lastActivity = Date.now();
+        result = await session.send(sendOpts);
       } else {
         throw retryErr;
       }
@@ -1080,6 +1085,24 @@ async function processTrigger(msg) {
       ({ content, sessionId, aborted, usage, modelUsage, totalCostUsd, durationMs, subtype } = result);
       content = stripLeadingThinkingMarker(content);
       console.log(`[stoa] OAuth retry completed for room=${room_id} msg=${message_id}, content=${content.length} chars`);
+    }
+
+    if (!aborted && !thinkingSigRetried && isThinkingSignatureError(content)) {
+      thinkingSigRetried = true;
+      console.log(`[stoa] thinking-signature 400 detected (content): ${content.slice(0, 120)}`);
+      send({ type: 'agent_stream_reset', room_id, message_id });
+      fullContent = '';
+      session.shutdown();
+      await backupSessionFile(targetDir, rid);
+      session = await prepareResume({ targetDir, rid, targetModel, toolsSupported: msg.tools_supported, env: envToUse, sessionKey, aggressive: true });
+      activeTriggers.set(message_id, { workdir: targetDir, session });
+      if (statusHandler) session.on('status', statusHandler);
+      sessionRef = session;
+      lastActivity = Date.now();
+      result = await session.send(sendOpts);
+      ({ content, sessionId, aborted, usage, modelUsage, totalCostUsd, durationMs, subtype } = result);
+      content = stripLeadingThinkingMarker(content);
+      console.log(`[stoa] thinking-signature recovery ${isThinkingSignatureError(content) ? 'FAILED' : 'ok'} for room=${room_id} msg=${message_id}`);
     }
 
     clearInterval(hangWatchdog);

--- a/test.js
+++ b/test.js
@@ -564,6 +564,9 @@ function runUnitTests() {
     const result = replaceThinkingBlock({ type: 'thinking', thinking: 'x', signature: 'abc', cache_control: { type: 'ephemeral' } });
     assert.deepStrictEqual(result, { type: 'thinking', thinking: 'x', signature: 'abc' });
   });
+  ut('replaceThinkingBlock — unsigned with cache_control → drop entirely (not just strip cache_control)', () => {
+    assert.strictEqual(replaceThinkingBlock({ type: 'thinking', thinking: 'x', cache_control: { type: 'ephemeral' } }), null);
+  });
   ut('replaceThinkingBlock — [thinking] marker → strip marker', () => {
     const result = replaceThinkingBlock({ type: 'text', text: '[thinking] hello' });
     assert.deepStrictEqual(result, { type: 'text', text: 'hello' });

--- a/test.js
+++ b/test.js
@@ -484,6 +484,119 @@ function runUnitTests() {
     assert.ok(validateRegexPattern(42) !== null);
   });
 
+  // ── Thinking-signature sanitizer ───────────────────────────────────────────
+  console.log('\n  [Thinking-signature sanitizer]');
+  const {
+    isThinkingSignatureError,
+    matchThinkingBlock,
+    replaceThinkingBlock,
+    stripLeadingThinkingMarker,
+  } = require('./lib/thinking-sanitizer');
+
+  // isThinkingSignatureError — positive cases
+  ut('isThinkingSignatureError — "Invalid signature in thinking block"', () => {
+    assert.strictEqual(isThinkingSignatureError('API Error: 400 messages.0.content.0: Invalid signature in thinking block'), true);
+  });
+  ut('isThinkingSignatureError — "cannot be modified"', () => {
+    assert.strictEqual(isThinkingSignatureError('API Error: 400 thinking or redacted_thinking blocks cannot be modified'), true);
+  });
+  ut('isThinkingSignatureError — "must remain as they were"', () => {
+    assert.strictEqual(isThinkingSignatureError('API Error: 400 thinking blocks must remain as they were in the original response'), true);
+  });
+
+  // isThinkingSignatureError — negative cases
+  ut('isThinkingSignatureError — empty string', () => {
+    assert.strictEqual(isThinkingSignatureError(''), false);
+  });
+  ut('isThinkingSignatureError — text > 600 chars (agent discussing the bug)', () => {
+    const longText = 'The thinking signature error happens when ' + 'x'.repeat(600);
+    assert.strictEqual(isThinkingSignatureError(longText), false);
+  });
+  ut('isThinkingSignatureError — "thinking" without detail keywords', () => {
+    assert.strictEqual(isThinkingSignatureError('thinking about the problem'), false);
+  });
+  ut('isThinkingSignatureError — auth error (no thinking)', () => {
+    assert.strictEqual(isThinkingSignatureError('API Error: 401 Unauthorized'), false);
+  });
+
+  // matchThinkingBlock — normal mode (strip unsigned/invalid only)
+  ut('matchThinkingBlock — unsigned thinking (no signature) → match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'thinking', thinking: 'hello' }), true);
+  });
+  ut('matchThinkingBlock — signed thinking → no match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'thinking', thinking: 'hello', signature: 'abc123' }), false);
+  });
+  ut('matchThinkingBlock — signed thinking with cache_control → match (strip cache_control)', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'thinking', thinking: 'x', signature: 'abc', cache_control: { type: 'ephemeral' } }), true);
+  });
+  ut('matchThinkingBlock — redacted_thinking without data → match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'redacted_thinking' }), true);
+  });
+  ut('matchThinkingBlock — redacted_thinking with data → no match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'redacted_thinking', data: 'base64...' }), false);
+  });
+  ut('matchThinkingBlock — text with [thinking] marker → match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'text', text: '[thinking] hello world' }), true);
+  });
+  ut('matchThinkingBlock — normal text → no match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'text', text: 'hello world' }), false);
+  });
+  ut('matchThinkingBlock — tool_use → no match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'tool_use', id: '1', name: 'read' }), false);
+  });
+
+  // matchThinkingBlock — stripAll mode (third-party/recovery)
+  ut('matchThinkingBlock stripAll — signed thinking → match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'thinking', thinking: 'x', signature: 'valid' }, { stripAll: true }), true);
+  });
+  ut('matchThinkingBlock stripAll — redacted_thinking with data → match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'redacted_thinking', data: 'base64' }, { stripAll: true }), true);
+  });
+  ut('matchThinkingBlock stripAll — normal text → no match', () => {
+    assert.strictEqual(matchThinkingBlock({ type: 'text', text: 'hello' }, { stripAll: true }), false);
+  });
+
+  // replaceThinkingBlock
+  ut('replaceThinkingBlock — unsigned thinking → null (drop)', () => {
+    assert.strictEqual(replaceThinkingBlock({ type: 'thinking', thinking: 'x' }), null);
+  });
+  ut('replaceThinkingBlock — signed with cache_control → strip cache_control only', () => {
+    const result = replaceThinkingBlock({ type: 'thinking', thinking: 'x', signature: 'abc', cache_control: { type: 'ephemeral' } });
+    assert.deepStrictEqual(result, { type: 'thinking', thinking: 'x', signature: 'abc' });
+  });
+  ut('replaceThinkingBlock — [thinking] marker → strip marker', () => {
+    const result = replaceThinkingBlock({ type: 'text', text: '[thinking] hello' });
+    assert.deepStrictEqual(result, { type: 'text', text: 'hello' });
+  });
+  ut('replaceThinkingBlock — [thinking] only → null (nothing left)', () => {
+    assert.strictEqual(replaceThinkingBlock({ type: 'text', text: '[thinking]' }), null);
+  });
+  ut('replaceThinkingBlock stripAll — signed thinking → null', () => {
+    assert.strictEqual(replaceThinkingBlock({ type: 'thinking', thinking: 'x', signature: 'valid' }, { stripAll: true }), null);
+  });
+
+  // stripLeadingThinkingMarker
+  ut('stripLeadingThinkingMarker — single marker', () => {
+    assert.strictEqual(stripLeadingThinkingMarker('[thinking] hello'), 'hello');
+  });
+  ut('stripLeadingThinkingMarker — multiple markers', () => {
+    assert.strictEqual(stripLeadingThinkingMarker('[thinking] [thinking] hello'), 'hello');
+  });
+  ut('stripLeadingThinkingMarker — no marker', () => {
+    assert.strictEqual(stripLeadingThinkingMarker('hello'), 'hello');
+  });
+  ut('stripLeadingThinkingMarker — non-string', () => {
+    assert.strictEqual(stripLeadingThinkingMarker(42), 42);
+  });
+
+  // Edge cases
+  ut('matchThinkingBlock — null input → false', () => {
+    assert.strictEqual(matchThinkingBlock(null), false);
+  });
+  ut('matchThinkingBlock — non-object → false', () => {
+    assert.strictEqual(matchThinkingBlock('string'), false);
+  });
+
   return { p, f };
 }
 

--- a/test.js
+++ b/test.js
@@ -1713,10 +1713,11 @@ async function run() {
     assert.ok('stoa.js' in r.body.files, 'stoa.js not in manifest');
   });
 
-  await test('GET /api/client/file/stoa.js — returns JS content', async () => {
+  await test('GET /api/client/file/stoa.js — returns JS with CLIENT_VERSION and thinking-sanitizer', async () => {
     const r = await req('GET', '/api/client/file/stoa.js');
     assert.strictEqual(r.status, 200);
-    assert.ok(r.raw.includes('CLIENT_VERSION'), 'CLIENT_VERSION not in stoa.js');
+    assert.ok(r.raw.includes('CLIENT_VERSION'), 'CLIENT_VERSION not in served file');
+    assert.ok(r.raw.includes('isThinkingSignatureError'), 'thinking-sanitizer functions missing');
   });
 
   await test('GET /api/client/file/../../server.js — path traversal blocked → 404', async () => {


### PR DESCRIPTION
## Summary
- **Lapis 1 (preventif):** `sanitizeThinking` endpoint-aware — direct Anthropic: drop unsigned thinking, redacted_thinking tanpa data, strip cache_control; third-party (base_url set): strip ALL thinking blocks
- **Lapis 2 (klasifikasi):** `isThinkingSignatureError` detects 400 by phrase (signature / cannot be modified / must remain as they were), not by provider — checks both exception path and content-as-result path
- **Lapis 3 (recovery):** one-shot per trigger — backup `.sig-bak` → aggressive strip → resume + retry
- **Refactor:** `prepareResume` consolidates 3 copy-pasted resume paths
- **Extract:** pure functions to `lib/thinking-sanitizer.js` for testability
- **Agent bundle:** esbuild bundles stoa.js + lib/* → dist/stoa.js on server startup, solving MODULE_NOT_FOUND when agents auto-update
- 29 new unit tests (289 total)

## Agent bundle mechanism
Root cause of agent crash: auto-update only downloads `stoa.js`, not `lib/` directory. `require('./lib/thinking-sanitizer')` fails with MODULE_NOT_FOUND on agent side.

Fix: server.js runs esbuild on startup to bundle `stoa.js` + all `lib/` dependencies into `dist/stoa.js`. Server serves the bundle via `/api/client/file/stoa.js`. Agent update protocol unchanged — still downloads one `stoa.js` file with all dependencies inlined.

## Design decisions
- No preventive strip of signed thinking from non-latest turns (no wire copy → would trigger "cannot be modified")
- Unsigned thinking dropped, not demoted to text (model mimicry proven)
- Recovery mutates JSONL with `.sig-bak` backup (no wire copy available)
- Content-path detection capped at 600 chars to avoid false positive on agent discussing the bug
- esbuild over multi-file update: no change to agent protocol, single-file download preserved

## Test plan
- [x] 289/289 tests passed (29 new thinking-sanitizer unit tests)
- [x] Bundle builds correctly: lib/ dependencies inlined, ws + claude-session external
- [ ] Verify: server restart builds bundle, agents auto-update successfully
- [ ] Verify: room with qwen via proxy → several turns → switch to Sonnet → no 400
- [ ] Verify: `[stoa] sanitized thinking residue` appears in logs on resume