### PR TITLE
R21: transcript sanitizer + escalation

### DIFF
--- a/lib/transcript-sanitizer.js
+++ b/lib/transcript-sanitizer.js
@@ -1,0 +1,180 @@
+'use strict';
+
+const PLACEHOLDER_TEXT = '(content elided)';
+const STUB_RESULT_TEXT = '(result unavailable)';
+
+function findAnomalies(entries) {
+  const toolUseIds = new Map();
+  const toolResultIds = new Map();
+  const anomalies = { orphanResults: [], missingResults: [], duplicateIds: [], emptyTurns: [] };
+
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!entry || typeof entry !== 'object') continue;
+
+    const content = entry.content;
+    if (!Array.isArray(content) || content.length === 0) {
+      if (entry.role === 'assistant' || entry.role === 'user') {
+        anomalies.emptyTurns.push(i);
+      }
+      continue;
+    }
+
+    for (let j = 0; j < content.length; j++) {
+      const block = content[j];
+      if (!block || typeof block !== 'object') continue;
+
+      if (block.type === 'tool_use' && block.id) {
+        if (toolUseIds.has(block.id)) {
+          anomalies.duplicateIds.push({ entryIdx: i, blockIdx: j, id: block.id, firstEntry: toolUseIds.get(block.id).entryIdx });
+        } else {
+          toolUseIds.set(block.id, { entryIdx: i, blockIdx: j });
+        }
+      }
+
+      if (block.type === 'tool_result' && block.tool_use_id) {
+        toolResultIds.set(block.tool_use_id, { entryIdx: i, blockIdx: j });
+      }
+    }
+  }
+
+  for (const [id, loc] of toolUseIds) {
+    if (!toolResultIds.has(id)) {
+      anomalies.missingResults.push({ id, entryIdx: loc.entryIdx });
+    }
+  }
+
+  for (const [id, loc] of toolResultIds) {
+    if (!toolUseIds.has(id)) {
+      anomalies.orphanResults.push({ id, entryIdx: loc.entryIdx, blockIdx: loc.blockIdx });
+    }
+  }
+
+  return anomalies;
+}
+
+function hasAnomalies(anomalies) {
+  return anomalies.orphanResults.length > 0
+    || anomalies.missingResults.length > 0
+    || anomalies.duplicateIds.length > 0
+    || anomalies.emptyTurns.length > 0;
+}
+
+function anomalyCount(anomalies) {
+  return anomalies.orphanResults.length + anomalies.missingResults.length
+    + anomalies.duplicateIds.length + anomalies.emptyTurns.length;
+}
+
+function fixAnomalies(entries, anomalies) {
+  let fixed = 0;
+
+  for (const dup of anomalies.duplicateIds) {
+    const entry = entries[dup.entryIdx];
+    if (!entry?.content?.[dup.blockIdx]) continue;
+    const block = entry.content[dup.blockIdx];
+    const newId = block.id + '-dup-' + dup.blockIdx;
+    block.id = newId;
+    for (const e of entries) {
+      if (!Array.isArray(e?.content)) continue;
+      for (const b of e.content) {
+        if (b?.type === 'tool_result' && b.tool_use_id === dup.id) {
+          const useEntry = entries[dup.firstEntry];
+          const origStillExists = useEntry?.content?.some(bl => bl?.type === 'tool_use' && bl.id === dup.id);
+          if (origStillExists) {
+            b.tool_use_id = newId;
+            break;
+          }
+        }
+      }
+    }
+    fixed++;
+  }
+
+  const orphanBlocksToRemove = new Map();
+  for (const orphan of anomalies.orphanResults) {
+    if (!orphanBlocksToRemove.has(orphan.entryIdx)) {
+      orphanBlocksToRemove.set(orphan.entryIdx, new Set());
+    }
+    orphanBlocksToRemove.get(orphan.entryIdx).add(orphan.blockIdx);
+    fixed++;
+  }
+  for (const [entryIdx, blockIdxs] of orphanBlocksToRemove) {
+    const entry = entries[entryIdx];
+    if (!Array.isArray(entry?.content)) continue;
+    entry.content = entry.content.filter((_, idx) => !blockIdxs.has(idx));
+  }
+
+  for (const missing of anomalies.missingResults) {
+    let targetIdx = missing.entryIdx + 1;
+    while (targetIdx < entries.length && entries[targetIdx]?.role === 'assistant') {
+      targetIdx++;
+    }
+    if (targetIdx < entries.length && entries[targetIdx]?.role === 'user') {
+      if (!Array.isArray(entries[targetIdx].content)) {
+        entries[targetIdx].content = [];
+      }
+      entries[targetIdx].content.push({
+        type: 'tool_result',
+        tool_use_id: missing.id,
+        content: STUB_RESULT_TEXT,
+      });
+    } else {
+      entries.splice(targetIdx, 0, {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: missing.id,
+          content: STUB_RESULT_TEXT,
+        }],
+      });
+    }
+    fixed++;
+  }
+
+  for (const emptyIdx of anomalies.emptyTurns) {
+    const entry = entries[emptyIdx];
+    if (!entry) continue;
+    if (!Array.isArray(entry.content) || entry.content.length === 0) {
+      entry.content = [{ type: 'text', text: PLACEHOLDER_TEXT }];
+      fixed++;
+    }
+  }
+
+  for (const [entryIdx] of orphanBlocksToRemove) {
+    const entry = entries[entryIdx];
+    if (entry && Array.isArray(entry.content) && entry.content.length === 0) {
+      entry.content = [{ type: 'text', text: PLACEHOLDER_TEXT }];
+    }
+  }
+
+  return fixed;
+}
+
+function escalationLevel(anomalies) {
+  const total = anomalyCount(anomalies);
+  if (total === 0) return 'none';
+  const lastEmpty = anomalies.emptyTurns.length > 0;
+  if (total > 5 || lastEmpty) return 'error';
+  if (total > 2 || anomalies.missingResults.length > 1) return 'warning';
+  return 'info';
+}
+
+function formatNotice(anomalies, fixed) {
+  const parts = [];
+  if (anomalies.orphanResults.length) parts.push(`${anomalies.orphanResults.length} orphan tool_result dropped`);
+  if (anomalies.missingResults.length) parts.push(`${anomalies.missingResults.length} missing tool_result stubbed`);
+  if (anomalies.duplicateIds.length) parts.push(`${anomalies.duplicateIds.length} duplicate ID renamed`);
+  if (anomalies.emptyTurns.length) parts.push(`${anomalies.emptyTurns.length} empty turn filled`);
+  return `transcript: fixed ${fixed} anomalies (${parts.join(', ')})`;
+}
+
+module.exports = {
+  PLACEHOLDER_TEXT,
+  STUB_RESULT_TEXT,
+  findAnomalies,
+  hasAnomalies,
+  anomalyCount,
+  fixAnomalies,
+  escalationLevel,
+  formatNotice,
+};

--- a/lib/transcript-sanitizer.js
+++ b/lib/transcript-sanitizer.js
@@ -153,8 +153,8 @@ function fixAnomalies(entries, anomalies) {
 function escalationLevel(anomalies) {
   const total = anomalyCount(anomalies);
   if (total === 0) return 'none';
-  const lastEmpty = anomalies.emptyTurns.length > 0;
-  if (total > 5 || lastEmpty) return 'error';
+  const hasEmptyTurns = anomalies.emptyTurns.length > 0;
+  if (total > 5 || hasEmptyTurns) return 'error';
   if (total > 2 || anomalies.missingResults.length > 1) return 'warning';
   return 'info';
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.17.5",
+  "version": "0.17.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.17.5",
+      "version": "0.17.7",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.4.177';
+const CLIENT_VERSION = '0.4.178';
 
 const WebSocket = require('ws');
 const readline = require('readline');
@@ -15,6 +15,7 @@ const { spawnSync } = require('child_process');
 
 const { ClaudeSession } = require('./claude-session');
 const { stripLeadingThinkingMarker, isThinkingSignatureError, matchThinkingBlock, replaceThinkingBlock, THINKING_MARKER_RE } = require('./lib/thinking-sanitizer');
+const { findAnomalies, hasAnomalies, fixAnomalies, escalationLevel, formatNotice } = require('./lib/transcript-sanitizer');
 
 let STOA_URL      = process.env.STOA_URL    || 'ws://localhost:3001';
 const ACTOR_ID    = parseInt(process.env.STOA_ACTOR_ID || '1');
@@ -270,6 +271,53 @@ function sanitizeThinking(workdir, sessionId, opts = {}) {
     stripAll ? 'stripped all thinking (third-party/recovery)' : 'sanitized thinking residue');
 }
 
+const transcriptNoticeEmitted = new Set();
+
+async function sanitizeTranscript(workdir, sessionId) {
+  const filePath = sessionFilePath(workdir, sessionId);
+  if (!filePath) return null;
+  try {
+    let raw;
+    try { raw = await fs.promises.readFile(filePath, 'utf8'); } catch { return null; }
+    if (!raw.includes('"tool_use"') && !raw.includes('"tool_result"') && !raw.includes('"content":[]')) return null;
+    const lines = raw.split('\n');
+    const entries = [];
+    const lineMap = [];
+    for (let i = 0; i < lines.length; i++) {
+      if (!lines[i].trim()) continue;
+      try {
+        entries.push(JSON.parse(lines[i]));
+        lineMap.push(i);
+      } catch {
+        entries.push(null);
+        lineMap.push(i);
+      }
+    }
+    const anomalies = findAnomalies(entries);
+    if (!hasAnomalies(anomalies)) return null;
+    const fixed = fixAnomalies(entries, anomalies);
+    if (fixed === 0) return null;
+    for (let j = 0; j < entries.length; j++) {
+      if (entries[j] && lineMap[j] !== undefined) {
+        lines[lineMap[j]] = JSON.stringify(entries[j]);
+      }
+    }
+    if (entries.length > lineMap.length) {
+      for (let j = lineMap.length; j < entries.length; j++) {
+        lines.push(JSON.stringify(entries[j]));
+      }
+    }
+    await fs.promises.writeFile(filePath, lines.join('\n'), 'utf8');
+    const level = escalationLevel(anomalies);
+    const notice = formatNotice(anomalies, fixed);
+    console.log(`[stoa] ${notice}`);
+    return { level, notice, anomalies, fixed };
+  } catch (err) {
+    console.error(`[stoa] transcript sanitizer error: ${err.message}`);
+    return null;
+  }
+}
+
 async function backupSessionFile(workdir, sessionId) {
   const filePath = sessionFilePath(workdir, sessionId);
   if (!filePath) return null;
@@ -287,6 +335,11 @@ async function backupSessionFile(workdir, sessionId) {
 async function prepareResume({ targetDir, rid, targetModel, toolsSupported, env, sessionKey, thirdParty = false, aggressive = false }) {
   if (rid && !compactsInFlight.has(targetDir)) {
     await sanitizeThinking(targetDir, rid, { thirdParty, aggressive });
+    const tsResult = await sanitizeTranscript(targetDir, rid);
+    if (tsResult && (tsResult.level === 'warning' || tsResult.level === 'error') && !transcriptNoticeEmitted.has(sessionKey)) {
+      transcriptNoticeEmitted.add(sessionKey);
+      try { send({ type: 'agent_system_event', status: `[${tsResult.level.toUpperCase()}] ${tsResult.notice}` }); } catch {}
+    }
   }
   const flags = rid ? ['--resume', rid] : [];
   if (targetModel) flags.push('--model', targetModel);

--- a/stoa.js
+++ b/stoa.js
@@ -279,7 +279,7 @@ async function sanitizeTranscript(workdir, sessionId) {
   try {
     let raw;
     try { raw = await fs.promises.readFile(filePath, 'utf8'); } catch { return null; }
-    if (!raw.includes('"tool_use"') && !raw.includes('"tool_result"') && !raw.includes('"content":[]')) return null;
+    if (!/"tool_use"|"tool_result"|"content":\[]/.test(raw)) return null;
     const lines = raw.split('\n');
     const entries = [];
     const lineMap = [];

--- a/test.js
+++ b/test.js
@@ -600,6 +600,185 @@ function runUnitTests() {
     assert.strictEqual(matchThinkingBlock('string'), false);
   });
 
+  // ── Transcript sanitizer (R21) ───────────────────────────────────────────
+  console.log('\n  [Transcript sanitizer]');
+  const {
+    PLACEHOLDER_TEXT,
+    STUB_RESULT_TEXT,
+    findAnomalies,
+    hasAnomalies,
+    anomalyCount,
+    fixAnomalies,
+    escalationLevel,
+    formatNotice,
+  } = require('./lib/transcript-sanitizer');
+
+  ut('findAnomalies — clean transcript → no anomalies', () => {
+    const entries = [
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }] },
+    ];
+    const a = findAnomalies(entries);
+    assert.strictEqual(hasAnomalies(a), false);
+    assert.strictEqual(anomalyCount(a), 0);
+  });
+
+  ut('findAnomalies — orphan tool_result detected', () => {
+    const entries = [
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'orphan1', content: 'x' }] },
+    ];
+    const a = findAnomalies(entries);
+    assert.strictEqual(a.orphanResults.length, 1);
+    assert.strictEqual(a.orphanResults[0].id, 'orphan1');
+  });
+
+  ut('findAnomalies — missing tool_result detected', () => {
+    const entries = [
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'tu2', name: 'Bash', input: {} }] },
+      { role: 'user', content: [{ type: 'text', text: 'ok' }] },
+    ];
+    const a = findAnomalies(entries);
+    assert.strictEqual(a.missingResults.length, 1);
+    assert.strictEqual(a.missingResults[0].id, 'tu2');
+  });
+
+  ut('findAnomalies — duplicate ID detected', () => {
+    const entries = [
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'dup1', name: 'Read', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'dup1', content: 'a' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'dup1', name: 'Edit', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'dup1', content: 'b' }] },
+    ];
+    const a = findAnomalies(entries);
+    assert.strictEqual(a.duplicateIds.length, 1);
+  });
+
+  ut('findAnomalies — empty turn detected', () => {
+    const entries = [
+      { role: 'assistant', content: [] },
+      { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    ];
+    const a = findAnomalies(entries);
+    assert.strictEqual(a.emptyTurns.length, 1);
+    assert.strictEqual(a.emptyTurns[0], 0);
+  });
+
+  ut('fixAnomalies — drop orphan tool_result', () => {
+    const entries = [
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'tu1', name: 'Read', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu1', content: 'ok' }, { type: 'tool_result', tool_use_id: 'orphan1', content: 'x' }] },
+    ];
+    const a = findAnomalies(entries);
+    const fixed = fixAnomalies(entries, a);
+    assert.strictEqual(fixed, 1);
+    assert.strictEqual(entries[1].content.length, 1);
+    assert.strictEqual(entries[1].content[0].tool_use_id, 'tu1');
+  });
+
+  ut('fixAnomalies — stub missing tool_result', () => {
+    const entries = [
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'tu3', name: 'Bash', input: {} }] },
+      { role: 'user', content: [{ type: 'text', text: 'ok' }] },
+    ];
+    const a = findAnomalies(entries);
+    const fixed = fixAnomalies(entries, a);
+    assert.strictEqual(fixed, 1);
+    const resultBlock = entries[1].content.find(b => b.type === 'tool_result' && b.tool_use_id === 'tu3');
+    assert.ok(resultBlock, 'stub tool_result injected');
+    assert.strictEqual(resultBlock.content, STUB_RESULT_TEXT);
+  });
+
+  ut('fixAnomalies — stub missing tool_result when no next turn exists', () => {
+    const entries = [
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'tu4', name: 'Read', input: {} }] },
+    ];
+    const a = findAnomalies(entries);
+    const fixed = fixAnomalies(entries, a);
+    assert.strictEqual(fixed, 1);
+    assert.strictEqual(entries.length, 2);
+    assert.strictEqual(entries[1].role, 'user');
+    assert.strictEqual(entries[1].content[0].tool_use_id, 'tu4');
+  });
+
+  ut('fixAnomalies — rename duplicate IDs', () => {
+    const entries = [
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'dup1', name: 'Read', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'dup1', content: 'a' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'dup1', name: 'Edit', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'dup1', content: 'b' }] },
+    ];
+    const a = findAnomalies(entries);
+    fixAnomalies(entries, a);
+    assert.notStrictEqual(entries[2].content[0].id, 'dup1');
+    assert.ok(entries[2].content[0].id.includes('dup'));
+  });
+
+  ut('fixAnomalies — fill empty turns with placeholder', () => {
+    const entries = [
+      { role: 'assistant', content: [] },
+    ];
+    const a = findAnomalies(entries);
+    fixAnomalies(entries, a);
+    assert.strictEqual(entries[0].content.length, 1);
+    assert.strictEqual(entries[0].content[0].text, PLACEHOLDER_TEXT);
+  });
+
+  ut('fixAnomalies — idempotent (run twice same result)', () => {
+    const entries = [
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'tu5', name: 'Read', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'orphan2', content: 'x' }] },
+    ];
+    const a1 = findAnomalies(entries);
+    fixAnomalies(entries, a1);
+    const snapshot = JSON.stringify(entries);
+    const a2 = findAnomalies(entries);
+    fixAnomalies(entries, a2);
+    assert.strictEqual(JSON.stringify(entries), snapshot);
+  });
+
+  ut('fixAnomalies — mixed anomalies all fixed', () => {
+    const entries = [
+      { role: 'assistant', content: [] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'orphan3', content: 'x' }] },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'tu6', name: 'Read', input: {} }] },
+    ];
+    const a = findAnomalies(entries);
+    assert.ok(hasAnomalies(a));
+    const fixed = fixAnomalies(entries, a);
+    assert.ok(fixed >= 3);
+    const a2 = findAnomalies(entries);
+    assert.strictEqual(hasAnomalies(a2), false);
+  });
+
+  ut('escalationLevel — none for clean', () => {
+    assert.strictEqual(escalationLevel({ orphanResults: [], missingResults: [], duplicateIds: [], emptyTurns: [] }), 'none');
+  });
+
+  ut('escalationLevel — info for 1-2 anomalies', () => {
+    assert.strictEqual(escalationLevel({ orphanResults: [1], missingResults: [], duplicateIds: [], emptyTurns: [] }), 'info');
+    assert.strictEqual(escalationLevel({ orphanResults: [1], missingResults: [1], duplicateIds: [], emptyTurns: [] }), 'info');
+  });
+
+  ut('escalationLevel — warning for >2 or >1 missing', () => {
+    assert.strictEqual(escalationLevel({ orphanResults: [1], missingResults: [1, 2], duplicateIds: [], emptyTurns: [] }), 'warning');
+  });
+
+  ut('escalationLevel — error for >5 anomalies', () => {
+    assert.strictEqual(escalationLevel({ orphanResults: [1, 2, 3], missingResults: [1, 2, 3], duplicateIds: [], emptyTurns: [] }), 'error');
+  });
+
+  ut('escalationLevel — error for empty turns', () => {
+    assert.strictEqual(escalationLevel({ orphanResults: [], missingResults: [], duplicateIds: [], emptyTurns: [0] }), 'error');
+  });
+
+  ut('formatNotice — describes fixes', () => {
+    const notice = formatNotice({ orphanResults: [1], missingResults: [1], duplicateIds: [], emptyTurns: [] }, 2);
+    assert.ok(notice.includes('fixed 2'));
+    assert.ok(notice.includes('orphan'));
+    assert.ok(notice.includes('missing'));
+  });
+
   return { p, f };
 }
 
@@ -1721,6 +1900,7 @@ async function run() {
     assert.strictEqual(r.status, 200);
     assert.ok(r.raw.includes('CLIENT_VERSION'), 'CLIENT_VERSION not in served file');
     assert.ok(r.raw.includes('isThinkingSignatureError'), 'thinking-sanitizer functions missing');
+    assert.ok(r.raw.includes('findAnomalies'), 'transcript-sanitizer functions missing');
   });
 
   await test('GET /api/client/file/../../server.js — path traversal blocked → 404', async () => {


### PR DESCRIPTION
## Summary
- **New `lib/transcript-sanitizer.js`** — pure functions for detecting and fixing JSONL transcript anomalies: orphan tool_results, missing tool_results, duplicate IDs, empty turns
- **Wired into `prepareResume()`** — sanitizes transcript before every `--resume`, after thinking-sanitizer
- **Escalation tiers** — INFO/WARNING/ERROR via `agent_system_event`, once per session key
- **18 unit tests** covering all anomaly types, idempotency, and mixed scenarios
- **Bundle assertion** — verifies `findAnomalies` present in served `dist/stoa.js`

## What it heals

| Anomaly | Cause | Fix |
|---------|-------|-----|
| Orphan `tool_result` | Compact truncated the `tool_use` turn | Drop block, fill empty turn |
| Missing `tool_result` | Agent crash mid-tool or compact truncated result | Inject stub result |
| Duplicate block ID | Race condition / replay bug | Rename subsequent, update matching results |
| Empty turn | Other sanitizer removed all blocks | Fill with placeholder text |

## Test plan
- [x] 18 unit tests for all pure functions (findAnomalies, fixAnomalies, escalationLevel, formatNotice)
- [x] Idempotency test (run twice → same result)
- [x] Mixed anomalies test (all types at once)
- [x] Bundle assertion (findAnomalies in dist/stoa.js)
- [x] Full test suite: 308/308 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)