### PR TITLE
parallel sub-agent dispatch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # Stoa — Todo
 
-_Audit terakhir: 2026-09-01 (Ara) — planning detail R12–R18 di `~/project/stoa-feature/hermes-adoption-plan.md`; detail R19–R30 di `~/project/stoa-feature/hermes-agent-research.md` section 7._
+_Audit terakhir: 2026-09-02 (Ara) — planning detail R12–R18 di `~/project/stoa-feature/hermes-adoption-plan.md`; detail R19–R30 di `~/project/stoa-feature/hermes-agent-research.md` section 7._
 
 _Urutan eksekusi ditetapkan 2026-09-01 (Ara, approved Aan). Logika: security & bug produksi → hardening bug-class terbukti → quick wins UX → fitur baru → carry-over._
 
@@ -8,11 +8,11 @@ _Urutan eksekusi ditetapkan 2026-09-01 (Ara, approved Aan). Logika: security & b
 
 - [x] **#0 Bug — Mention wakeup orchestrator tidak berfungsi** _(S)_ — ✓ `3a6b928`: root cause: kondisi `enqueueParentWake` mensyaratkan `parent_message_id` non-null, yang hanya di-set oleh `/sub-agent-trigger`. Sub-agent via `@mention cascade` tidak punya `parent_message_id` → orchestrator tidak pernah di-wake. Fix: hapus syarat `&& doneRow.parent_message_id` — semua sub-agent completion wake parent. 329/329 tests pass. Dicatat 2026-09-02.
 
-## Batch 1 — Kritis: bug produksi & security `[exec 1–3]`
+## Batch 1 — Kritis: bug produksi & security `[exec 1–3]` ✓ SELESAI
 
 - [x] **#1 R20 — Audit ReDoS regex** _(S)_ — ✓ `3a54d68`: safeRegexTest() rejects nested quantifiers; fixes automation matches_regex + writeEnv escaping; benchmark 30k char = 0ms.
-- [ ] **#2 R19 — Thinking-signature management lengkap** _(S–M)_ — sempurnakan fix `42f0bbc`: (1) preventif per-endpoint — Anthropic: thinking block hanya di assistant message terakhir; proxy/third-party (AI Platforms): strip SEMUA thinking + strip `cache_control`; (2) klasifikasi 400 by frasa error, jangan gate by provider; (3) recovery one-shot hanya di wire copy — JANGAN mutasi canonical store/DB.
-- [ ] **#3 R21 — Transcript sanitizer + escalation** _(M)_ — heal pre-send di wire copy (orphan tool_result drop, tool_call tanpa result → stub, dedupe id, empty turn → placeholder); WARNING → ERROR di threshold → notice satu-kali per session via status channel (tidak masuk transcript).
+- [x] **#2 R19 — Thinking-signature management lengkap** _(S–M)_ — ✓ PR #64 (v0.17.x): 3-layer defense — strip unsigned thinking, per-endpoint preventif, one-shot recovery di wire copy.
+- [x] **#3 R21 — Transcript sanitizer + escalation** _(M)_ — ✓ PR #65 (v0.17.x): heal pre-send (orphan drop, stub, dedupe, placeholder), WARNING→ERROR threshold, notice via status channel.
 
 ## Batch 2 — Hardening bug-class terbukti `[exec 4–9]`
 
@@ -48,11 +48,13 @@ _Urutan eksekusi ditetapkan 2026-09-01 (Ara, approved Aan). Logika: security & b
 - [ ] **#20 Webhook/API** — HTTP endpoint untuk trigger agent dari external (CI/CD, monitoring, script). Masih relevan; belum ada endpoint trigger generik (baru automation Slack + proactive message agent-auth). Naikkan kalau muncul use case CI/CD konkret.
 - [ ] **#21 Context window indicator** — indikator visual saat conversation mendekati batas context. Sebagian tertutup oleh configurable auto-compact threshold (Settings); R14+R29 mengecilkan kebutuhannya lagi.
 
-## Done (audit 2026-09-01)
+## Done (audit 2026-09-02)
 
 - [x] **Agent config via UI** — sudah ada: `public/js/settings/agents-add.js` + install-script generation (bash/PowerShell) di server.
 - [x] **Multi-model support** — arah berubah dari "adapter per vendor" ke **AI Platforms**: custom platform (base_url + API keys, vendor generic/ollama), Ollama Cloud proxy, model discovery, switch model per room. OpenAI-compatible & LiteLLM tertutup lewat custom platform base_url.
 - [x] **Scheduled triggers + schedule UI** — PR #58/#59 (v0.17.x).
+- [x] **Mention-based sub-agent orchestration** — PR #66 (v0.17.8): @mention trigger, sub-agent system prompts, BE-Stoa/FE-Stoa/TechWriter-Stoa/TechLead-Stoa agents.
+- [x] **Parallel sub-agent dispatch** — PR #67 (pending merge): sub-agent @mentions fire concurrently, regular AI agents tetap sequential; `mentionBoundary` regex module-level.
 
 ## Trash
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.18.2",
+      "version": "0.19.0",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -4420,6 +4420,16 @@ wss.on('connection', (ws, req) => {
         "UPDATE messages SET state='error', content=CASE WHEN content='' THEN '(interrupted — agent disconnected)' ELSE content END WHERE state IN ('streaming','requesting') AND participant_id IN (SELECT rp.id FROM room_participants rp WHERE rp.actor_id=?)"
       ).run(agentActorId);
       if (cleaned.changes) console.log(`[agent] Cleaned ${cleaned.changes} orphaned message(s) from Actor #${agentActorId}`);
+      // Reject all pending promises for this actor so caller sequences can continue/unblock
+      for (const [mId, pending] of [...pendingAgents]) {
+        const meta = pendingActorMeta.get(mId);
+        if (meta?.actor_id === agentActorId) {
+          pendingAgents.delete(mId);
+          pendingActorMeta.delete(mId);
+          if (meta.room_id) broadcast(meta.room_id, { type: 'message_state', message_id: mId, state: 'error' });
+          pending.reject(new Error('agent_disconnected'));
+        }
+      }
       // Clean up pendingCompacts — remove only this agent; if no agents remain, unstick UI
       for (const [roomId, cs] of pendingCompacts) {
         const idx = cs.agents.indexOf(agentActorId);
@@ -4599,7 +4609,12 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
       turnCount++;
       const currentAgent = agents[i];
       const prefetchedCtx = { allParticipants: participantsStmt.all(roomId), wdRow, repliedMsg };
-      await triggerAiResponse(roomId, currentAgent, content, replyTo, attachments, prefetchedCtx);
+      try {
+        await triggerAiResponse(roomId, currentAgent, content, replyTo, attachments, prefetchedCtx);
+      } catch (e) {
+        // Disconnect or timeout — DB + UI already updated by the rejection path; continue to next agent
+        console.log(`[trigger] ${currentAgent.sub_agent ? currentAgent.sub_agent.label : currentAgent.name} failed (${e.message}), continuing sequence`);
+      }
       if (seq.cancelled) break;
 
       const lastMsg = db.prepare(`
@@ -4711,7 +4726,24 @@ async function handleHumanMessage(roomId, content, attachments, replyTo, senderW
 
   if (allAiParts.length > 0) {
     const ordered = resolveAgentOrder(content, allAiParts, roomId);
-    triggerAgentsSequential(roomId, ordered, content, messageId, attachments || []).catch(e => console.error('[trigger] sequence error:', e));
+    const subAgentMentions = ordered.filter(a => a.sub_agent);
+    const parentMentions   = ordered.filter(a => !a.sub_agent);
+
+    // Sub-agents fire in parallel — independent of conversation flow
+    if (subAgentMentions.length > 0) {
+      const maxParallel = parseInt(process.env.MAX_PARALLEL_SUB_AGENTS || '4');
+      (async () => {
+        for (let i = 0; i < subAgentMentions.length; i += maxParallel) {
+          const batch = subAgentMentions.slice(i, i + maxParallel);
+          await Promise.allSettled(batch.map(a => triggerAiResponse(roomId, a, content, messageId, attachments || [])));
+        }
+      })().catch(e => console.error('[trigger] parallel sub-agent error:', e));
+    }
+
+    // Parent agents run sequentially
+    if (parentMentions.length > 0) {
+      triggerAgentsSequential(roomId, parentMentions, content, messageId, attachments || []).catch(e => console.error('[trigger] sequence error:', e));
+    }
   }
 }
 
@@ -4791,9 +4823,22 @@ async function triggerSkillResponse(roomId, ai, prompt) {
   const agentWs = agentClients.get(ai.actor_id);
 
   if (agentWs && agentWs.readyState === 1) {
+    const skillRunTimeoutMs = parseInt(process.env.AGENT_RUN_TIMEOUT_MS || String(15 * 60 * 1000));
     await new Promise((resolve, reject) => {
-      pendingAgents.set(msgId, { resolve, reject });
-      pendingActorMeta.set(msgId, { actor_name: ai.name, avatar_color: ai.avatar_color, avatar_symbol: ai.avatar_symbol, avatar_url: ai.avatar_url || null });
+      const timeoutTimer = setTimeout(() => {
+        if (!pendingAgents.has(msgId)) return;
+        pendingAgents.delete(msgId);
+        pendingActorMeta.delete(msgId);
+        db.prepare("UPDATE messages SET state='error', content=? WHERE id=?")
+          .run(`(timeout — ${ai.name} did not respond in ${Math.round(skillRunTimeoutMs / 60000)} minutes)`, msgId);
+        broadcast(roomId, { type: 'message_state', message_id: msgId, state: 'error' });
+        reject(new Error('agent_timeout'));
+      }, skillRunTimeoutMs);
+      pendingAgents.set(msgId, {
+        resolve: (v) => { clearTimeout(timeoutTimer); resolve(v); },
+        reject:  (e) => { clearTimeout(timeoutTimer); reject(e); },
+      });
+      pendingActorMeta.set(msgId, { actor_id: ai.actor_id, room_id: roomId, actor_name: ai.name, avatar_color: ai.avatar_color, avatar_symbol: ai.avatar_symbol, avatar_url: ai.avatar_url || null });
       agentWs.send(JSON.stringify({
         type: 'agent_trigger',
         room_id: roomId,
@@ -5129,9 +5174,22 @@ async function triggerAiResponse(roomId, ai, prompt, replyTo, attachments = [], 
     const sessionId = subAgent
       ? getSubAgentSession(ai.participant_id, subAgent.id)
       : getSession(ai.participant_id);
+    const agentRunTimeoutMs = parseInt(process.env.AGENT_RUN_TIMEOUT_MS || String(15 * 60 * 1000));
     await new Promise((resolve, reject) => {
-      pendingAgents.set(msgId, { resolve, reject });
-      pendingActorMeta.set(msgId, { actor_name: ai.name, avatar_color: ai.avatar_color, avatar_symbol: ai.avatar_symbol, avatar_url: ai.avatar_url || null, sub_agent_label: subAgent?.label || null });
+      const timeoutTimer = setTimeout(() => {
+        if (!pendingAgents.has(msgId)) return;
+        pendingAgents.delete(msgId);
+        pendingActorMeta.delete(msgId);
+        db.prepare("UPDATE messages SET state='error', content=? WHERE id=?")
+          .run(`(timeout — ${displayName} did not respond in ${Math.round(agentRunTimeoutMs / 60000)} minutes)`, msgId);
+        broadcast(roomId, { type: 'message_state', message_id: msgId, state: 'error' });
+        reject(new Error('agent_timeout'));
+      }, agentRunTimeoutMs);
+      pendingAgents.set(msgId, {
+        resolve: (v) => { clearTimeout(timeoutTimer); resolve(v); },
+        reject:  (e) => { clearTimeout(timeoutTimer); reject(e); },
+      });
+      pendingActorMeta.set(msgId, { actor_id: ai.actor_id, room_id: roomId, actor_name: ai.name, avatar_color: ai.avatar_color, avatar_symbol: ai.avatar_symbol, avatar_url: ai.avatar_url || null, sub_agent_label: subAgent?.label || null });
       const triggerBaseUrl = getPublicUrl(`localhost:${PORT}`);
       const fullAttachments = (attachments || []).map(a => ({
         ...a,

--- a/server.js
+++ b/server.js
@@ -387,35 +387,40 @@ async function cascadeMentionsAfterWake(roomId, parent) {
     WHERE rsa.room_id=? AND sa.enabled=1
   `).all(roomId);
 
-  const cascadeAgents = [];
+  const subAgentsCascade = [];
+  const regularAgentsCascade = [];
 
   const mentionBoundary = (name) => new RegExp(`(?:^|\\s)@${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|[.,!?;:]|$)`);
 
   for (const sa of linkedSubs) {
     if (mentionBoundary(sa.label).test(lastMsg.content)) {
       const parentAgent = allAi.find(a => a.actor_id === sa.parent_actor_id);
-      if (parentAgent) {
-        cascadeAgents.push({ ...parentAgent, sub_agent: sa });
-      }
+      if (parentAgent) subAgentsCascade.push({ ...parentAgent, sub_agent: sa });
     }
   }
 
   for (const other of allAi) {
     if (other.actor_id !== parent.actor_id && mentionBoundary(other.name).test(lastMsg.content)) {
-      const alreadyQueued = cascadeAgents.some(a => a.actor_id === other.actor_id);
-      if (!alreadyQueued) cascadeAgents.push({ ...other, sub_agent: null });
+      const alreadyQueued = regularAgentsCascade.some(a => a.actor_id === other.actor_id);
+      if (!alreadyQueued) regularAgentsCascade.push({ ...other, sub_agent: null });
     }
   }
 
-  if (!cascadeAgents.length) {
+  if (!subAgentsCascade.length && !regularAgentsCascade.length) {
     wakeCascadeDepth.delete(roomId);
     return;
   }
 
-  console.log(`[wake-cascade] depth ${depth}: ${cascadeAgents.map(a => a.sub_agent ? a.sub_agent.label : a.name).join(', ')} in room ${roomId}`);
+  const allCascadeLabels = [...subAgentsCascade.map(a => a.sub_agent.label), ...regularAgentsCascade.map(a => a.name)];
+  console.log(`[wake-cascade] depth ${depth}: ${allCascadeLabels.join(', ')} in room ${roomId}`);
   wakeCascadeDepth.set(roomId, depth);
   try {
-    await triggerAgentsSequential(roomId, cascadeAgents, lastMsg.content, null, []);
+    for (const sa of subAgentsCascade) {
+      triggerAiResponse(roomId, sa, lastMsg.content, null, []).catch(e => console.error('[wake-cascade sub-agent] parallel error:', e));
+    }
+    if (regularAgentsCascade.length > 0) {
+      await triggerAgentsSequential(roomId, regularAgentsCascade, lastMsg.content, null, []);
+    }
   } finally {
     if (wakeCascadeDepth.get(roomId) === depth) wakeCascadeDepth.delete(roomId);
   }
@@ -4588,6 +4593,8 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
       WHERE rp.room_id=? AND a.type='ai' AND rp.notify_on_message=1
     `);
 
+    const firedSubAgentIds = new Set();
+
     for (let i = 0; i < Math.min(agents.length, maxTurns); i++) {
       if (seq.cancelled) break;
       turnCount++;
@@ -4612,7 +4619,7 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
           }
         }
 
-        // Cascade sub-agent mentions in responses
+        // Sub-agent mentions in responses fire in parallel (task-based, independent of conversation flow)
         const linkedSubs = db.prepare(`
           SELECT sa.*, a.name AS parent_name FROM room_sub_agents rsa
           JOIN sub_agents sa ON sa.id=rsa.sub_agent_id
@@ -4620,11 +4627,12 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
           WHERE rsa.room_id=? AND sa.enabled=1
         `).all(roomId);
         for (const sa of linkedSubs) {
-          if (lastMsg.content.includes('@' + sa.label)) {
-            const alreadyQueued = agents.slice(i + 1).some(a => a.sub_agent?.id === sa.id);
-            if (!alreadyQueued) {
-              const parent = allAiInRoom.find(a => a.actor_id === sa.parent_actor_id);
-              if (parent) agents.push({ ...parent, sub_agent: sa });
+          if (lastMsg.content.includes('@' + sa.label) && !firedSubAgentIds.has(sa.id)) {
+            const parent = allAiInRoom.find(a => a.actor_id === sa.parent_actor_id);
+            if (parent) {
+              firedSubAgentIds.add(sa.id);
+              triggerAiResponse(roomId, { ...parent, sub_agent: sa }, lastMsg.content, replyTo, attachments, prefetchedCtx)
+                .catch(e => console.error('[sub-agent parallel] dispatch error:', e));
             }
           }
         }

--- a/server.js
+++ b/server.js
@@ -357,6 +357,7 @@ async function drainWake(wakeId) {
 // next sub-agent → cascade triggers it → repeat.
 const MAX_WAKE_CASCADE_DEPTH = 5;
 const wakeCascadeDepth = new Map(); // roomId → current depth
+const mentionBoundary = (name) => new RegExp(`(?:^|\\s)@${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|[.,!?;:]|$)`);
 
 async function cascadeMentionsAfterWake(roomId, parent) {
   const depth = (wakeCascadeDepth.get(roomId) || 0) + 1;
@@ -389,8 +390,6 @@ async function cascadeMentionsAfterWake(roomId, parent) {
 
   const subAgentsCascade = [];
   const regularAgentsCascade = [];
-
-  const mentionBoundary = (name) => new RegExp(`(?:^|\\s)@${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?=\\s|[.,!?;:]|$)`);
 
   for (const sa of linkedSubs) {
     if (mentionBoundary(sa.label).test(lastMsg.content)) {
@@ -4613,7 +4612,7 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
       if (lastMsg?.content) {
         const allAiInRoom = allAiStmt.all(roomId);
         for (const other of allAiInRoom) {
-          if (other.actor_id !== currentAgent.actor_id && lastMsg.content.includes('@' + other.name)) {
+          if (other.actor_id !== currentAgent.actor_id && mentionBoundary(other.name).test(lastMsg.content)) {
             const alreadyQueued = agents.slice(i + 1).some(a => a.actor_id === other.actor_id);
             if (!alreadyQueued) agents.push({ ...other, sub_agent: null });
           }
@@ -4627,7 +4626,7 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
           WHERE rsa.room_id=? AND sa.enabled=1
         `).all(roomId);
         for (const sa of linkedSubs) {
-          if (lastMsg.content.includes('@' + sa.label) && !firedSubAgentIds.has(sa.id)) {
+          if (mentionBoundary(sa.label).test(lastMsg.content) && !firedSubAgentIds.has(sa.id)) {
             const parent = allAiInRoom.find(a => a.actor_id === sa.parent_actor_id);
             if (parent) {
               firedSubAgentIds.add(sa.id);

--- a/server.js
+++ b/server.js
@@ -4575,7 +4575,7 @@ const activeSequences = new Map(); // roomId → { cancelled: bool }
 const roomIdleBus = new (require('events').EventEmitter)();
 roomIdleBus.setMaxListeners(0); // unbounded — one listener per queued room
 
-async function triggerAgentsSequential(roomId, agents, content, replyTo, attachments) {
+async function triggerAgentsSequential(roomId, agents, content, replyTo, attachments, initialFiredSubAgentIds = new Set()) {
   const maxTurns = parseInt(process.env.MAX_AI_TURNS || '5');
   const seq = { cancelled: false };
   activeSequences.set(roomId, seq);
@@ -4602,7 +4602,8 @@ async function triggerAgentsSequential(roomId, agents, content, replyTo, attachm
       WHERE rp.room_id=? AND a.type='ai' AND rp.notify_on_message=1
     `);
 
-    const firedSubAgentIds = new Set();
+    // Pre-populate with sub-agents already fired by initial parallel dispatch (prevents double-firing)
+    const firedSubAgentIds = new Set(initialFiredSubAgentIds);
 
     for (let i = 0; i < Math.min(agents.length, maxTurns); i++) {
       if (seq.cancelled) break;
@@ -4730,6 +4731,7 @@ async function handleHumanMessage(roomId, content, attachments, replyTo, senderW
     const parentMentions   = ordered.filter(a => !a.sub_agent);
 
     // Sub-agents fire in parallel — independent of conversation flow
+    const initialFiredSubAgentIds = new Set(subAgentMentions.map(a => a.sub_agent.id));
     if (subAgentMentions.length > 0) {
       const maxParallel = parseInt(process.env.MAX_PARALLEL_SUB_AGENTS || '4');
       (async () => {
@@ -4740,9 +4742,9 @@ async function handleHumanMessage(roomId, content, attachments, replyTo, senderW
       })().catch(e => console.error('[trigger] parallel sub-agent error:', e));
     }
 
-    // Parent agents run sequentially
+    // Parent agents run sequentially; pass fired sub-agent IDs to prevent double-firing from cascade
     if (parentMentions.length > 0) {
-      triggerAgentsSequential(roomId, parentMentions, content, messageId, attachments || []).catch(e => console.error('[trigger] sequence error:', e));
+      triggerAgentsSequential(roomId, parentMentions, content, messageId, attachments || [], initialFiredSubAgentIds).catch(e => console.error('[trigger] sequence error:', e));
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -188,6 +188,28 @@ function runUnitTests() {
     assert.strictEqual(ordered.length, 2);
   });
 
+  // Parallel sub-agent dispatch split (mirrors handleHumanMessage dispatch logic)
+  ut('dispatch split — sub_agent entries separated from parent entries', () => {
+    const agents = [
+      { name: 'Ara', sub_agent: null },
+      { name: 'Ara', sub_agent: { id: 1, label: 'probe' } },
+      { name: 'Ara', sub_agent: { id: 2, label: 'reviewer' } },
+    ];
+    const subAgentMentions = agents.filter(a => a.sub_agent);
+    const parentMentions   = agents.filter(a => !a.sub_agent);
+    assert.strictEqual(subAgentMentions.length, 2, 'should have 2 sub-agents');
+    assert.strictEqual(parentMentions.length, 1, 'should have 1 parent');
+    assert.ok(subAgentMentions.every(a => a.sub_agent !== null), 'all sub-agents should have sub_agent field');
+  });
+
+  ut('dispatch split — no sub_agent mentions → all go to sequential', () => {
+    const agents = [{ name: 'Ara', sub_agent: null }, { name: 'Idris', sub_agent: null }];
+    const subAgentMentions = agents.filter(a => a.sub_agent);
+    const parentMentions   = agents.filter(a => !a.sub_agent);
+    assert.strictEqual(subAgentMentions.length, 0);
+    assert.strictEqual(parentMentions.length, 2);
+  });
+
   // parseDocFilename (mirrors server logic)
   const parseDocFilename = name => {
     const m = name.match(/^(.+)\.([a-z]{2})\.md$/);

--- a/test.js
+++ b/test.js
@@ -210,6 +210,24 @@ function runUnitTests() {
     assert.strictEqual(parentMentions.length, 2);
   });
 
+  ut('dispatch split — initialFiredSubAgentIds built from initial parallel batch', () => {
+    const agents = [
+      { name: 'Ara', sub_agent: null },
+      { name: 'Ara', sub_agent: { id: 5, label: 'probe' } },
+      { name: 'Ara', sub_agent: { id: 7, label: 'reviewer' } },
+    ];
+    const subAgentMentions = agents.filter(a => a.sub_agent);
+    const initialFiredSubAgentIds = new Set(subAgentMentions.map(a => a.sub_agent.id));
+    assert.ok(initialFiredSubAgentIds.has(5), 'probe id should be in fired set');
+    assert.ok(initialFiredSubAgentIds.has(7), 'reviewer id should be in fired set');
+    assert.strictEqual(initialFiredSubAgentIds.size, 2);
+    // Simulates firedSubAgentIds = new Set(initialFiredSubAgentIds) in triggerAgentsSequential
+    const firedSubAgentIds = new Set(initialFiredSubAgentIds);
+    // Now a cascade mention of probe (id=5) should be blocked
+    const wouldFireAgain = !firedSubAgentIds.has(5);
+    assert.strictEqual(wouldFireAgain, false, 'should not re-fire probe that was already dispatched');
+  });
+
   // parseDocFilename (mirrors server logic)
   const parseDocFilename = name => {
     const m = name.match(/^(.+)\.([a-z]{2})\.md$/);


### PR DESCRIPTION
## Summary

Memperbaiki 3 bug orchestration (B1, B2, B4 dari planning doc):

### B1/B4 — Promise lifecycle: timeout + rejection path saat disconnect
- Setiap `await new Promise()` di `triggerAiResponse` dan `triggerSkillResponse` sekarang punya timeout (default 15 menit, override via `AGENT_RUN_TIMEOUT_MS`)
- Saat timeout: message di-update ke `state='error'`, broadcast `message_state` ke UI agar bubble berhenti berputar, promise di-reject
- Saat agent disconnect (`ws.on('close')`): iterasi semua `pendingAgents`, reject semua yang milik actor tersebut, broadcast `message_state` per message
- `pendingActorMeta` sekarang menyimpan `actor_id` dan `room_id` untuk cross-reference saat disconnect
- `triggerAgentsSequential` loop kini wrap `triggerAiResponse` dalam try/catch — agent failure tidak lagi membunuh seluruh sequence

### B2 — Parallel sub-agent initial dispatch
- `handleHumanMessage`: pisahkan `resolveAgentOrder` result menjadi `subAgentMentions` (punya `sub_agent`) dan `parentMentions`
- Sub-agent mentions → `Promise.allSettled` per batch (`MAX_PARALLEL_SUB_AGENTS`, default 4)
- Parent agents → tetap `triggerAgentsSequential` (tidak berubah)
- Cascade dalam sequential loop (response agent menyebut sub-agent) → sudah parallel dari commit sebelumnya
- `cascadeMentionsAfterWake` → sudah parallel dari commit sebelumnya

## Test Plan
- [x] Unit test: dispatch split logic (sub_agent vs parent filtering)
- [x] Unit test: dispatch split dengan no sub-agent mentions
- [ ] Manual: 2+ sub-agent di-mention dalam satu pesan → keduanya streaming bersamaan
- [ ] Manual: agent disconnect mid-run → bubble berhenti, pesan jadi error, sequence lanjut ke agent berikutnya
- [ ] Manual: timeout (set `AGENT_RUN_TIMEOUT_MS=5000` untuk test) → pesan jadi error dengan keterangan menit

## Notes
- B3 (mention tidak ter-render di FE) → handled oleh FE-Stoa, PR terpisah
- Tidak ada schema change, tidak ada docs update (behavior internal/orchestration)