### PR TITLE
sub-agent token optimization — fixed workdir + history limit per tier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.19.1",
+      "version": "0.19.2",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.19.1",
+  "version": "0.19.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -5038,11 +5038,14 @@ async function triggerAiResponse(roomId, ai, prompt, replyTo, attachments = [], 
 
   const nowUtc = new Date().toISOString().replace('T', ' ').slice(0, 16) + ' UTC';
 
+  const historyLimit = subAgent
+    ? ({ quick: 3, standard: 5, deep: 10 }[subAgent.tier] ?? 5)
+    : 10;
   const history = db.prepare(`
     SELECT a.name, m.content, m.image_url, m.file_url, m.file_name, m.attachments, m.created_at, rp.actor_id FROM messages m
     JOIN room_participants rp ON rp.id=m.participant_id
     JOIN actors a ON a.id=rp.actor_id
-    WHERE m.room_id=? AND m.state='complete' ORDER BY m.created_at DESC LIMIT 10
+    WHERE m.room_id=? AND m.state='complete' ORDER BY m.created_at DESC LIMIT ${historyLimit}
   `).all(roomId);
   const rawHistory = history.slice().reverse().map(r => ({
     role: r.actor_id === ai.actor_id ? 'assistant' : 'user',

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.4.185';
+const CLIENT_VERSION = '0.4.186';
 
 const WebSocket = require('ws');
 const readline = require('readline');
@@ -849,14 +849,21 @@ function classifyModelError(m = '') {
 
 async function processTrigger(msg) {
   const { room_id, message_id } = msg;
-  const workdir = msg.workdir || process.env.STOA_WORK_DIR || os.homedir();
   const subAgent = msg.sub_agent || null;
+  // Sub-agents without an explicit workdir use ~/stoa-agent/ — a clean, minimal directory
+  // that does not carry the project's CLAUDE.md, preventing accidental context injection.
+  const subAgentDefaultWorkdir = path.join(os.homedir(), 'stoa-agent');
+  const workdir = msg.workdir || (subAgent ? subAgentDefaultWorkdir : null) || process.env.STOA_WORK_DIR || os.homedir();
 
   if (!fs.existsSync(workdir)) {
-    const label = subAgent?.label || 'agent';
-    console.error(`[trigger] workdir does not exist on this machine: ${workdir}`);
-    send({ type: 'agent_complete', room_id, message_id, content: `Workdir tidak ditemukan di mesin ini: \`${workdir}\``, ai_model: undefined, result_meta: { exit_reason: 'error' } });
-    return;
+    if (subAgent && workdir === subAgentDefaultWorkdir) {
+      fs.mkdirSync(workdir, { recursive: true });
+    } else {
+      const label = subAgent?.label || 'agent';
+      console.error(`[trigger] workdir does not exist on this machine: ${workdir}`);
+      send({ type: 'agent_complete', room_id, message_id, content: `Workdir tidak ditemukan di mesin ini: \`${workdir}\``, ai_model: undefined, result_meta: { exit_reason: 'error' } });
+      return;
+    }
   }
 
   activeTriggers.set(message_id, { workdir, session: null });

--- a/stoa.js
+++ b/stoa.js
@@ -859,7 +859,6 @@ async function processTrigger(msg) {
     if (subAgent && workdir === subAgentDefaultWorkdir) {
       fs.mkdirSync(workdir, { recursive: true });
     } else {
-      const label = subAgent?.label || 'agent';
       console.error(`[trigger] workdir does not exist on this machine: ${workdir}`);
       send({ type: 'agent_complete', room_id, message_id, content: `Workdir tidak ditemukan di mesin ini: \`${workdir}\``, ai_model: undefined, result_meta: { exit_reason: 'error' } });
       return;


### PR DESCRIPTION
## Summary

- **P1 — Fixed workdir `~/stoa-agent/`**: sub-agent tanpa custom workdir sekarang spawn di `~/stoa-agent/` (dibuat otomatis kalau belum ada), bukan di workdir project parent. Ini mencegah CLAUDE.md besar (instruksi dev, tool list, dll) masuk ke context sub-agent secara tak sengaja. Sub-agent tetap bisa baca file eksternal via Bash/Read kalau diinstruksikan eksplisit.

- **P2 — History limit per tier**: `quick=3`, `standard=5`, `deep=10`. Main agent tetap 10. Sub-agent `quick` tidak butuh 10 pesan history untuk task atomik.

- **DB**: TechLead-Stoa, BE-Stoa, FE-Stoa, TechWriter-Stoa workdir di-clear ke NULL (sudah dilakukan langsung di DB). Researcher tetap di `~/stoa-global-agents` (custom, intentional).

## Root cause

Sub-agent pakai workdir yang sama dengan parent → Claude Code CLI auto-load CLAUDE.md dari direktori aktif → context window sub-agent membengkak dengan instruksi yang tidak relevan dengan task mereka.

## Test plan
- [x] 335/335 tests passed
- [ ] Server restart → verify sub-agent spawn di `~/stoa-agent/` (observasi dari log `[trigger]`)
- [ ] Trigger sub-agent dan cek token usage via cost chip

## Pending (P3, P4 di PR berikutnya)
- P3: system prompt per-session via `--append-system-prompt`
- P4: replace curl orchestration dengan @mention (backend wake tetap server-side)