### PR TITLE
fix bubble stuck — mid-trigger disconnect + reconnect wake drain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -3507,6 +3507,14 @@ wss.on('connection', (ws, req) => {
       ws.send(JSON.stringify({ type: 'set_config', max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 1, session_idle_ttl: parseInt(process.env.SESSION_IDLE_TTL) || 5, auto_compact_threshold_kb: parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB) || 500 }));
       const connectedActor = db.prepare('SELECT id, name, type, adapter, adapter_config, avatar_color, avatar_symbol, avatar_url, created_at FROM actors WHERE id=?').get(agentActorId);
       if (connectedActor) broadcastGlobal({ type: 'actor_status', actor: { ...connectedActor, online: true, client_version: msg.client_version || null } });
+      // Drain any pending wakes left by a disconnect mid-trigger or prior crash.
+      const reconnectWakes = db.prepare(
+        "SELECT pw.id FROM pending_wakes pw JOIN room_participants rp ON rp.id=pw.parent_participant_id WHERE rp.actor_id=?"
+      ).all(agentActorId);
+      if (reconnectWakes.length) {
+        console.log(`[agent] draining ${reconnectWakes.length} pending wake(s) for Actor #${agentActorId} on reconnect`);
+        for (const r of reconnectWakes) drainWake(r.id).catch(e => console.error('[wake] reconnect drain error:', e.message));
+      }
     }
 
     // ── Agent reports scan results
@@ -5189,6 +5197,14 @@ async function triggerAiResponse(roomId, ai, prompt, replyTo, attachments = [], 
       console.log(`[trigger] sent to ${displayName} agent, msgId=${msgId}`);
     });
 
+  } else {
+    // Agent disconnected between the initial online check and here (race condition).
+    // Update bubble to error so UI shows feedback, then throw so drainWake can retry.
+    console.log(`[trigger] ${displayName} disconnected mid-trigger, msgId=${msgId} — marking error for retry`);
+    db.prepare("UPDATE messages SET state='error', content=? WHERE id=?")
+      .run(`(${displayName} terputus saat trigger — akan dicoba ulang otomatis)`, msgId);
+    broadcast(roomId, { type: 'message_state', message_id: msgId, state: 'error' });
+    throw new Error('agent_disconnected_mid_trigger');
   }
 }
 


### PR DESCRIPTION
## Root Cause

Race condition di `triggerAiResponse`: ada 2 check `agentWs.readyState` terpisah:
1. Line ~4937 (awal function): kalau offline → insert system_event, return tanpa throw
2. Line ~5142 (setelah bubble dibuat): kalau disconnect sementara itu → function ends, **bubble tetap streaming, tidak throw**

Karena tidak throw, `drainWake` delete `pending_wake` dan tidak retry. Bubble stuck selamanya di state streaming.

## Fix

**1. `triggerAiResponse` — tambah `else` throw setelah send block (server.js)**
Kalau agent disconnect antara check awal dan actual send: update bubble ke `error` + throw `agent_disconnected_mid_trigger`. `drainWake` catch block akan increment attempts dan **tidak delete** pending_wake → ready untuk retry.

**2. `agent_connect` handler — drain pending wakes on reconnect (server.js)**
Saat agent reconnect, query `pending_wakes` untuk rooms yang agent-nya terlibat dan drain semua. Ini memastikan wake yang tersisa (dari race condition atau crash) di-retry segera saat agent online kembali — bukan tunggu server restart berikutnya.

## Tests

335/335 passed ✓