### PR TITLE
fix R14 migration: remove redundant BEGIN/COMMIT wrapper

### DIFF
--- a/migrations/20260903-compact-failure-cooldown.sql
+++ b/migrations/20260903-compact-failure-cooldown.sql
@@ -1,6 +1,4 @@
 -- R14: durable compact-failure cooldown on ai_sessions
 -- Prevents repeated compact attempts after failure (MAX semantics: longer cooldown wins).
-BEGIN;
 ALTER TABLE ai_sessions ADD COLUMN compact_failure_cooldown_until TEXT;
 ALTER TABLE ai_sessions ADD COLUMN compact_failure_error TEXT;
-COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.20.3",
+      "version": "0.20.4",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.20.3",
+  "version": "0.20.4",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Migration `20260903-compact-failure-cooldown.sql` di PR #78 ter-squash-merge dengan `BEGIN;`/`COMMIT;` masih ada
- Server migration runner sudah wrap sendiri dengan `BEGIN TRANSACTION` / `COMMIT` — nested transaction di SQLite akan fail, menyebabkan R14 columns tidak ter-apply saat server restart
- Fix: hapus `BEGIN;` dan `COMMIT;` dari migration file

## Root cause

`gh pr merge --squash` terjadi sebelum commit fix sempat masuk ke PR. Squash commit di master capture versi lama.

## Test plan

- [ ] Migration runner di server.js wrap dengan `BEGIN TRANSACTION` / `COMMIT` (line 474-477) — sudah diverifikasi
- [ ] Test suite (337/337) passed dengan versi tanpa BEGIN/COMMIT