### PR TITLE
R16: fix sub-agent idle timer scoping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.20.4",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.20.4",
+      "version": "0.21.1",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/stoa.js
+++ b/stoa.js
@@ -1291,7 +1291,7 @@ async function processTrigger(msg) {
   } finally {
     if (sessionRef && statusHandler) sessionRef.removeListener('status', statusHandler);
     activeTriggers.delete(message_id);
-    if (targetDir) startSessionIdleTimer(`${targetDir}::${room_id}`);
+    if (targetDir) startSessionIdleTimer(sessionKey);
     drainQueue();
   }
 }

--- a/test.js
+++ b/test.js
@@ -384,6 +384,18 @@ function runUnitTests() {
     assert.strictEqual(cleanErrorText('\n\n'), 'unknown error');
   });
 
+  // R16: sessionKey scoping — sub-agent idle timer must use its own key, not parent key
+  ut('R16 — sub-agent sessionKey is distinct from parent sessionKey', () => {
+    const workdir = '/project/foo';
+    const roomId = 42;
+    const subAgentId = 7;
+    const parentKey = `${workdir}::${roomId}`;
+    const subKey = `${workdir}::${roomId}::sub:${subAgentId}`;
+    assert.notStrictEqual(subKey, parentKey, 'sub-agent key must differ from parent key');
+    assert.ok(subKey.includes('::sub:'), 'sub-agent key must contain ::sub: marker');
+    assert.ok(!parentKey.includes('::sub:'), 'parent key must not contain ::sub: marker');
+  });
+
   // formatCostRollup token formatter (mirrors _fmtTok / client _fmtTokens)
   const _fmtTok = (n) => (n >= 1000 ? (n / 1000).toFixed(n >= 10000 ? 0 : 1) + 'k' : String(n || 0));
   ut('_fmtTok — sub-1k raw, 1k–10k one decimal, ≥10k rounded', () => {


### PR DESCRIPTION
## Summary

- **Bug found**: In `processTrigger` finally block, `startSessionIdleTimer` was always called with `${targetDir}::${room_id}` (parent session key), even when running as a sub-agent
- Sub-agent session key is `${targetDir}::${room_id}::sub:${subAgentId}` — distinct from parent key (see `getSession`)
- This caused: (1) parent session idle timer incorrectly reset after every sub-agent completion, (2) sub-agent session idle timer not refreshed post-completion
- **Fix**: use `sessionKey` variable (already set correctly per trigger type) instead of hardcoded parent key

## Change

`stoa.js` line 1294:
```js
// Before (bug):
if (targetDir) startSessionIdleTimer(`${targetDir}::${room_id}`);

// After (fix):
if (targetDir) startSessionIdleTimer(sessionKey);
```

## Test plan

- [ ] Unit test added: R16 — sub-agent sessionKey is distinct from parent sessionKey
- [ ] 345/345 tests pass
- [ ] No migration needed (stoa.js only)