### PR TITLE
fix proactive message @mention cascade — agent @mentions now trigger sub-agents

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -32,7 +32,7 @@ _Urutan eksekusi ditetapkan 2026-09-01 (Ara, approved Aan). Logika: security & b
 
 ## Batch 4 — Fitur baru `[exec 14–19]`
 
-- [ ] **#14 R28 — `busy_input_mode`: interrupt/queue/steer** _(M–L)_ — jawaban arsitektural untuk SIGTERM-restart yang membunuh kerja in-flight agent (insiden 2026-09-01); `queue` = antre dengan UI sliding window, `steer` = suntik ke run berjalan.
+- [x] **#14 R28 — `busy_input_mode`: interrupt/queue/steer** _(M–L)_ — ✓ PR #87: `queue` = antre dengan UI sliding window, `steer` = suntik ke run berjalan; jawaban arsitektural untuk SIGTERM-restart yang membunuh kerja in-flight agent (insiden 2026-09-01).
 - [ ] **#15 R26 — Stoa Doctor + session tooling** _(M)_ — `/api/health/db` (pure function: size via `page_count*page_size`, WAL, freelist, counts); tiap check gagal bawa instruksi fix; `pinned` di sessions (kebal auto-archive); **import sesi dari JSONL Claude Code**.
 - [ ] **#16 R27 — Sidebar recency grouping** _(S–M)_ — head-run adaptif (potong di jeda ≥30 menit, fuzzy-merge bucket) + collapsible groups; pure function, portable 1:1.
 - [ ] **#17 R25 — Memory per-room/agent** _(M–L)_ — file markdown editable di UI, frozen snapshot per session start (jaga prompt cache), budget char, drift detection + backup, staged approval untuk tulisan background.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.26.1",
+      "version": "0.26.2",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -426,6 +426,53 @@ async function cascadeMentionsAfterWake(roomId, parent) {
   }
 }
 
+// Cascade @mentions from a proactive agent message (same logic as wake-cascade but content is known upfront).
+async function cascadeMentionsFromProactive(roomId, senderActorId, content) {
+  if (!content.includes('@')) return;
+
+  const allAi = db.prepare(`
+    SELECT rp.id as participant_id, a.id as actor_id, a.name, a.adapter, a.adapter_config, a.avatar_color, a.avatar_symbol, a.avatar_url
+    FROM room_participants rp JOIN actors a ON a.id=rp.actor_id
+    WHERE rp.room_id=? AND a.type='ai' AND rp.notify_on_message=1
+  `).all(roomId);
+
+  const linkedSubs = db.prepare(`
+    SELECT sa.*, a.name AS parent_name FROM room_sub_agents rsa
+    JOIN sub_agents sa ON sa.id=rsa.sub_agent_id
+    JOIN actors a ON a.id=sa.parent_actor_id
+    WHERE rsa.room_id=? AND sa.enabled=1
+  `).all(roomId);
+
+  const subAgentsCascade = [];
+  const regularAgentsCascade = [];
+
+  for (const sa of linkedSubs) {
+    if (mentionBoundary(sa.label).test(content)) {
+      const parentAgent = allAi.find(a => a.actor_id === sa.parent_actor_id);
+      if (parentAgent) subAgentsCascade.push({ ...parentAgent, sub_agent: sa });
+    }
+  }
+
+  for (const other of allAi) {
+    if (other.actor_id !== senderActorId && mentionBoundary(other.name).test(content)) {
+      const alreadyQueued = regularAgentsCascade.some(a => a.actor_id === other.actor_id);
+      if (!alreadyQueued) regularAgentsCascade.push({ ...other, sub_agent: null });
+    }
+  }
+
+  if (!subAgentsCascade.length && !regularAgentsCascade.length) return;
+
+  const labels = [...subAgentsCascade.map(a => a.sub_agent.label), ...regularAgentsCascade.map(a => a.name)];
+  console.log(`[proactive-cascade] room ${roomId}: triggering ${labels.join(', ')}`);
+
+  for (const sa of subAgentsCascade) {
+    triggerAiResponse(roomId, sa, content, null, []).catch(e => console.error('[proactive-cascade sub-agent]', e.message));
+  }
+  if (regularAgentsCascade.length > 0) {
+    await triggerAgentsSequential(roomId, regularAgentsCascade, content, null, []);
+  }
+}
+
 // Drain any wakes left by a crash/restart (R1). Called after server boot.
 function drainPendingWakesOnStartup() {
   const rows = db.prepare('SELECT id FROM pending_wakes ORDER BY id').all();
@@ -1930,6 +1977,8 @@ const server = http.createServer(async (req, res) => {
 
     broadcast(roomId, { type: 'message_new', message: row });
     broadcastGlobal({ type: 'room_activity', room_id: roomId });
+    // Cascade any @mentions in the proactive message (fire-and-forget)
+    cascadeMentionsFromProactive(roomId, agentId, content).catch(e => console.error('[proactive-cascade]', e.message));
     return json(res, { message_id: messageId });
   }
 

--- a/test.js
+++ b/test.js
@@ -1265,6 +1265,19 @@ async function run() {
       pmMessageId = r.body.message_id;
     });
 
+    await test('POST /api/rooms/:id/message — @mention in content does not break response', async () => {
+      if (!pmRoomId || !pmActorId || !pmActorSecret) { console.log('    (skipped)'); return; }
+      const r = await rawReq('POST', `/api/rooms/${pmRoomId}/message`,
+        JSON.stringify({ content: '@NonexistentAgent please review this' }),
+        'application/json',
+        { 'X-Agent-Id': String(pmActorId), 'X-Agent-Secret': pmActorSecret }
+      );
+      assert.strictEqual(r.status, 200, `@mention proactive should still return 200: ${r.status}`);
+      assert.ok(r.body.message_id, 'message_id missing in @mention response');
+      // cleanup extra message
+      await req('DELETE', `/api/messages/${r.body.message_id}`);
+    });
+
     await test('POST /api/rooms/:id/message — wrong secret → 403', async () => {
       if (!pmRoomId || !pmActorId) { console.log('    (skipped)'); return; }
       const r = await rawReq('POST', `/api/rooms/${pmRoomId}/message`,


### PR DESCRIPTION
## Summary
- Proactive message endpoint (`POST /api/rooms/:id/message`) hanya insert ke DB + broadcast — tidak ada @mention cascade
- Human messages lewat `handleHumanMessage` sudah punya cascade logic, tapi proactive messages tidak
- Akibatnya @mention sub-agent di proactive message tidak pernah ter-trigger (bug diam, tidak ada error)

## Fix
- Tambah `cascadeMentionsFromProactive(roomId, senderActorId, content)` — logika identik `cascadeMentionsAfterWake`, content diketahui upfront
- Fire-and-forget setelah `broadcast()` di proactive endpoint

## Test plan
- [x] 368/368 tests passed
- [x] Test baru: `@mention in content does not break response`

🤖 Generated with [Claude Code](https://claude.com/claude-code)