### PR TITLE
R30: debug share bundle (#19)

### DIFF
--- a/db/schema.sqlite.sql
+++ b/db/schema.sqlite.sql
@@ -301,3 +301,16 @@ CREATE TABLE IF NOT EXISTS memory_pending_writes (
   proposed_at TEXT NOT NULL DEFAULT (datetime('now')),
   status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','approved','rejected'))
 );
+
+CREATE TABLE IF NOT EXISTS debug_bundles (
+  id          TEXT PRIMARY KEY,
+  format      INTEGER NOT NULL DEFAULT 1,
+  redacted    INTEGER NOT NULL DEFAULT 1,
+  read_count  INTEGER NOT NULL DEFAULT 0,
+  max_reads   INTEGER NOT NULL DEFAULT 1,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at  TEXT NOT NULL,
+  file_path   TEXT NOT NULL,
+  size_bytes  INTEGER NOT NULL DEFAULT 0,
+  consent_at  TEXT NOT NULL
+);

--- a/lib/debug-bundle.js
+++ b/lib/debug-bundle.js
@@ -1,0 +1,132 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const ENVELOPE_FORMAT = 1;
+const HOME_RE = new RegExp(os.homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+
+const REDACT_PATTERNS = [
+  [/(?:sk-|anthropic-|key-|token-|Bearer )[A-Za-z0-9_\-]{20,}/g, '[REDACTED]'],
+  [/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, '[REDACTED-EMAIL]'],
+  [/(?:password|secret|token|apiKey|api_key)\s*[:=]\s*\S+/gi, '$& [REDACTED]'.replace(/\$&/, match => match.split(/[:=]/)[0] + ': [REDACTED]')],
+  [/\b(?!127\.0\.0\.1\b)(?!0\.0\.0\.0\b)(?!localhost\b)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[REDACTED-IP]'],
+];
+
+function forceRedact(input) {
+  if (input == null) return input;
+  if (typeof input === 'number' || typeof input === 'boolean') return input;
+  if (Array.isArray(input)) return input.map(forceRedact);
+  if (typeof input === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(input)) {
+      if (/^(adapter_config|secret|api_key|apiKey)$/i.test(k)) { out[k] = '[REDACTED]'; continue; }
+      out[k] = forceRedact(v);
+    }
+    return out;
+  }
+  if (typeof input !== 'string') return input;
+  let s = input;
+  s = s.replace(HOME_RE, '~');
+  s = s.replace(/(?:sk-|anthropic-|key-|token-|Bearer )[A-Za-z0-9_\-]{20,}/g, '[REDACTED]');
+  s = s.replace(/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, '[REDACTED-EMAIL]');
+  s = s.replace(/(?:password|secret|token|apiKey|api_key)\s*[:=]\s*\S+/gi, m => m.split(/[:=]/)[0] + ': [REDACTED]');
+  s = s.replace(/\b(?!127\.0\.0\.1\b)(?!0\.0\.0\.0\b)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[REDACTED-IP]');
+  return s;
+}
+
+function collectDiagnostics(db) {
+  const health = {};
+  try {
+    health.page_count = db.pragma('page_count', { simple: true });
+    health.page_size = db.pragma('page_size', { simple: true });
+    health.size_bytes = health.page_count * health.page_size;
+    health.freelist_pages = db.pragma('freelist_count', { simple: true });
+    health.journal_mode = db.pragma('journal_mode', { simple: true });
+    const walPath = db.name + '-wal';
+    try { health.wal_size_bytes = fs.statSync(walPath).size; } catch { health.wal_size_bytes = 0; }
+  } catch (e) { health.error = e.message; }
+
+  let rooms = [];
+  try {
+    rooms = db.prepare(`SELECT id, title, created_at, archived_at, max_ai_turns, model FROM rooms`).all();
+  } catch {}
+
+  let agents = [];
+  try {
+    agents = db.prepare(`SELECT id, name, type, adapter FROM actors WHERE type='ai'`).all();
+  } catch {}
+
+  let sessions = [];
+  try {
+    sessions = db.prepare(`SELECT id, room_id, status, last_active_at, compact_failure_error, pinned FROM ai_sessions`).all();
+  } catch {}
+
+  let settings = [];
+  try {
+    settings = db.prepare(`SELECT key, value, scope FROM settings`).all()
+      .map(s => ({ key: s.key, value: forceRedact(s.value), scope: s.scope }));
+  } catch {}
+
+  const counts = {};
+  try {
+    counts.rooms = db.prepare('SELECT COUNT(*) as n FROM rooms WHERE archived_at IS NULL').get().n;
+    counts.messages = db.prepare('SELECT COUNT(*) as n FROM messages').get().n;
+    counts.ai_sessions = db.prepare('SELECT COUNT(*) as n FROM ai_sessions').get().n;
+    counts.agents = db.prepare("SELECT COUNT(*) as n FROM actors WHERE type='ai'").get().n;
+  } catch {}
+
+  const logDir = path.join(path.dirname(db.name), 'logs');
+  const serverLog = readLogTail(path.join(logDir, 'stoa.log'), 200);
+  const errorLog = readLogTail(path.join(logDir, 'stoa.err'), 100);
+
+  return {
+    health,
+    rooms_summary: rooms,
+    agents_summary: agents,
+    sessions,
+    settings,
+    counts,
+    server_log_tail: serverLog,
+    error_log_tail: errorLog,
+  };
+}
+
+function readLogTail(filepath, lines) {
+  try {
+    const content = fs.readFileSync(filepath, 'utf8');
+    const arr = content.split('\n');
+    return arr.slice(-lines).join('\n');
+  } catch { return null; }
+}
+
+function buildEnvelope(diagnostics) {
+  const pkg = (() => { try { return require('../package.json'); } catch { return {}; } })();
+  return forceRedact({
+    format: ENVELOPE_FORMAT,
+    redacted: true,
+    created: new Date().toISOString(),
+    stoa_version: pkg.version || 'unknown',
+    node_version: process.version,
+    platform: process.platform,
+    uptime_seconds: Math.floor(process.uptime()),
+    memory: process.memoryUsage(),
+    data: diagnostics,
+  });
+}
+
+function gcDebugBundles(db) {
+  let cleaned = 0;
+  try {
+    const expired = db.prepare(
+      "SELECT id, file_path FROM debug_bundles WHERE expires_at <= datetime('now') OR read_count >= max_reads"
+    ).all();
+    for (const bundle of expired) {
+      try { fs.unlinkSync(bundle.file_path); } catch {}
+      db.prepare('DELETE FROM debug_bundles WHERE id=?').run(bundle.id);
+      cleaned++;
+    }
+  } catch {}
+  return cleaned;
+}
+
+module.exports = { forceRedact, collectDiagnostics, buildEnvelope, gcDebugBundles, ENVELOPE_FORMAT };

--- a/lib/debug-bundle.js
+++ b/lib/debug-bundle.js
@@ -5,13 +5,6 @@ const os = require('os');
 const ENVELOPE_FORMAT = 1;
 const HOME_RE = new RegExp(os.homedir().replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
 
-const REDACT_PATTERNS = [
-  [/(?:sk-|anthropic-|key-|token-|Bearer )[A-Za-z0-9_\-]{20,}/g, '[REDACTED]'],
-  [/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, '[REDACTED-EMAIL]'],
-  [/(?:password|secret|token|apiKey|api_key)\s*[:=]\s*\S+/gi, '$& [REDACTED]'.replace(/\$&/, match => match.split(/[:=]/)[0] + ': [REDACTED]')],
-  [/\b(?!127\.0\.0\.1\b)(?!0\.0\.0\.0\b)(?!localhost\b)\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b/g, '[REDACTED-IP]'],
-];
-
 function forceRedact(input) {
   if (input == null) return input;
   if (typeof input === 'number' || typeof input === 'boolean') return input;
@@ -81,7 +74,7 @@ function collectDiagnostics(db) {
 
   return {
     health,
-    rooms_summary: rooms,
+    rooms_summary: rooms.map(r => ({ ...r, title: forceRedact(r.title) })),
     agents_summary: agents,
     sessions,
     settings,

--- a/migrations/20260906-debug-bundles.sql
+++ b/migrations/20260906-debug-bundles.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS debug_bundles (
+  id          TEXT PRIMARY KEY,
+  format      INTEGER NOT NULL DEFAULT 1,
+  redacted    INTEGER NOT NULL DEFAULT 1,
+  read_count  INTEGER NOT NULL DEFAULT 0,
+  max_reads   INTEGER NOT NULL DEFAULT 1,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at  TEXT NOT NULL,
+  file_path   TEXT NOT NULL,
+  size_bytes  INTEGER NOT NULL DEFAULT 0,
+  consent_at  TEXT NOT NULL
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/public/js/settings/doctor.js
+++ b/public/js/settings/doctor.js
@@ -25,6 +25,7 @@ async function sLoadDoctorTab() {
   }
   _doctorLoading = false;
   _renderDoctor();
+  _debugBundleLoadList();
 }
 
 function _renderDoctor() {
@@ -97,6 +98,7 @@ function _renderDoctor() {
     ${section('Counts', countRows)}
     ${section('Health Checks', checksHtml || '<div style="font-size:12.5px;color:var(--h-ink-faint)">No checks available.</div>')}
     ${_renderImportSection()}
+    ${_renderDebugBundleSection()}
   `;
 }
 
@@ -112,6 +114,93 @@ function _renderImportSection() {
       </div>
       <div id="doctor-import-result" style="margin-top:8px;font-size:12.5px;color:var(--h-ink-mute)"></div>
     </div>`;
+}
+
+function _renderDebugBundleSection() {
+  return `
+    <div style="margin-bottom:20px">
+      <div style="font-size:11px;font-weight:600;color:var(--h-ink-mute);text-transform:uppercase;letter-spacing:.06em;margin-bottom:6px">Debug Bundle</div>
+      <div style="font-size:12.5px;color:var(--h-ink-mute);margin-bottom:10px">Create a diagnostic snapshot for troubleshooting. All secrets are force-redacted. No message content is included.</div>
+      <div id="debug-bundle-actions" style="margin-bottom:8px">
+        <button id="debug-bundle-create-btn" onclick="_debugBundleShowConsent()" style="background:none;border:1px solid var(--h-border);border-radius:6px;padding:6px 14px;font-size:12.5px;color:var(--h-ink);cursor:pointer">Create debug bundle</button>
+      </div>
+      <div id="debug-bundle-consent" style="display:none;border:1px solid var(--h-border);border-radius:8px;padding:14px;margin-bottom:10px;background:var(--h-code-bg,oklch(0.97 0 0))">
+        <div style="font-size:12.5px;color:var(--h-ink);margin-bottom:10px;line-height:1.5">
+          This bundle will contain:<br>
+          &bull; Database health stats &amp; table counts<br>
+          &bull; Room and agent metadata (no message content)<br>
+          &bull; Recent server log lines (force-redacted)<br><br>
+          The bundle will be <b>readable only once</b>, then auto-deleted.<br>
+          Expires in 24 hours. All API keys, emails, and secrets are redacted.
+        </div>
+        <div style="display:flex;gap:8px">
+          <button onclick="_debugBundleHideConsent()" style="background:none;border:1px solid var(--h-border);border-radius:6px;padding:5px 12px;font-size:12px;color:var(--h-ink-mute);cursor:pointer">Cancel</button>
+          <button onclick="_debugBundleCreate()" style="background:var(--h-accent,oklch(0.55 0.15 250));border:none;border-radius:6px;padding:5px 12px;font-size:12px;color:#fff;cursor:pointer">I understand, create bundle</button>
+        </div>
+      </div>
+      <div id="debug-bundle-list"></div>
+      <div id="debug-bundle-status" style="font-size:12.5px;color:var(--h-ink-mute);margin-top:4px"></div>
+    </div>`;
+}
+
+function _debugBundleShowConsent() {
+  const el = document.getElementById('debug-bundle-consent');
+  if (el) el.style.display = 'block';
+}
+function _debugBundleHideConsent() {
+  const el = document.getElementById('debug-bundle-consent');
+  if (el) el.style.display = 'none';
+}
+
+async function _debugBundleCreate() {
+  _debugBundleHideConsent();
+  const status = document.getElementById('debug-bundle-status');
+  if (status) { status.textContent = 'Creating bundle...'; status.style.color = 'var(--h-ink-mute)'; }
+  try {
+    const r = await fetch('/api/debug/bundle', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ consent: true }) });
+    if (!r.ok) { const e = await r.json().catch(() => ({})); throw new Error(e.error || r.statusText); }
+    const data = await r.json();
+    if (status) { status.textContent = 'Bundle created.'; status.style.color = 'var(--h-green,oklch(0.65 0.16 145))'; }
+    _debugBundleLoadList();
+  } catch (e) {
+    if (status) { status.textContent = `Failed: ${e.message}`; status.style.color = 'var(--h-red,oklch(0.6 0.18 27))'; }
+  }
+}
+
+async function _debugBundleLoadList() {
+  const container = document.getElementById('debug-bundle-list');
+  if (!container) return;
+  try {
+    const bundles = await fjson('/api/debug/bundles');
+    if (!bundles.length) { container.innerHTML = ''; return; }
+    container.innerHTML = bundles.map(b => {
+      const expires = new Date(b.expires_at + 'Z');
+      const remaining = Math.max(0, Math.round((expires - Date.now()) / 60000));
+      return `<div style="display:flex;align-items:center;gap:10px;padding:6px 0;border-top:1px solid var(--h-hair-soft)">
+        <span style="font-size:11.5px;font-family:var(--h-mono);color:var(--h-ink-mute)">${b.id.slice(0, 8)}</span>
+        <span style="font-size:11px;color:var(--h-ink-faint)">${_fmtBytes(b.size_bytes)} &middot; expires ${remaining}m</span>
+        <button onclick="_debugBundleDownload('${b.id}')" style="margin-left:auto;background:none;border:1px solid var(--h-border);border-radius:4px;padding:2px 8px;font-size:11px;color:var(--h-ink);cursor:pointer">download</button>
+        <button onclick="_debugBundleDelete('${b.id}')" style="background:none;border:1px solid var(--h-border);border-radius:4px;padding:2px 8px;font-size:11px;color:var(--h-red,oklch(0.6 0.18 27));cursor:pointer">delete</button>
+      </div>`;
+    }).join('');
+  } catch {}
+}
+
+function _debugBundleDownload(id) {
+  const a = document.createElement('a');
+  a.href = `/api/debug/bundle/${id}`;
+  a.download = `stoa-debug-${id.slice(0, 8)}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => _debugBundleLoadList(), 1000);
+}
+
+async function _debugBundleDelete(id) {
+  try {
+    await fetch(`/api/debug/bundle/${id}`, { method: 'DELETE' });
+    _debugBundleLoadList();
+  } catch {}
 }
 
 async function _doctorHandleImport(input) {

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const { WebSocketServer } = require('ws');
 const db = require('./db');
 const { ClaudeSession } = require('./claude-session');
 const { validateScheduleSpec, computeNextRun, nextRunAfterSkip } = require('./lib/schedule');
+const { collectDiagnostics, buildEnvelope, gcDebugBundles } = require('./lib/debug-bundle');
 const fallbackSessions = new Map();
 
 // R15: unique identifier for this server boot. Sessions tagged with a different
@@ -842,6 +843,8 @@ function gcTick() {
         const deleted = reclaimUploads(orphans);
         console.log(`[gc] reclaimed ${deleted} orphaned upload(s)`);
       }
+      const bundlesCleaned = gcDebugBundles(db);
+      if (bundlesCleaned) console.log(`[gc] cleaned ${bundlesCleaned} debug bundle(s)`);
     } catch (e) { console.error('[gc] tick error:', e.message); }
   });
 }
@@ -2286,6 +2289,80 @@ const server = http.createServer(async (req, res) => {
       return json(res, { page_count: pageCount, page_size: pageSize, size_bytes: sizeBytes, freelist_pages: freelistPages, wal_size_bytes: walSizeBytes, journal_mode: journalMode, counts, checks });
     } catch (e) {
       return json(res, { error: e.message }, 500);
+    }
+  }
+
+  // ── R30: Debug share bundle ──
+  if (req.method === 'POST' && url.pathname === '/api/debug/bundle') {
+    if (!req._authUser) return json(res, { error: 'unauthorized' }, 401);
+    const body = parseJsonBody(await readBody(req));
+    if (!body || body.consent !== true) return json(res, { error: 'explicit consent required (consent: true)' }, 400);
+    try {
+      const id = crypto.randomUUID();
+      const diagnostics = collectDiagnostics(db);
+      const envelope = buildEnvelope(diagnostics);
+      const debugDir = path.join(UPLOADS_DIR, 'debug');
+      if (!fs.existsSync(debugDir)) fs.mkdirSync(debugDir, { recursive: true });
+      const filePath = path.join(debugDir, `${id}.json`);
+      const content = JSON.stringify(envelope, null, 2);
+      fs.writeFileSync(filePath, content);
+      const now = new Date().toISOString();
+      const expires = new Date(Date.now() + 24 * 3600_000).toISOString();
+      db.prepare(
+        `INSERT INTO debug_bundles (id, format, redacted, read_count, max_reads, created_at, expires_at, file_path, size_bytes, consent_at) VALUES (?, 1, 1, 0, 1, ?, ?, ?, ?, ?)`
+      ).run(id, now, expires, filePath, Buffer.byteLength(content), now);
+      return json(res, { id, created_at: now, expires_at: expires, size_bytes: Buffer.byteLength(content) });
+    } catch (e) {
+      return json(res, { error: e.message }, 500);
+    }
+  }
+
+  if (req.method === 'GET' && url.pathname === '/api/debug/bundles') {
+    if (!req._authUser) return json(res, { error: 'unauthorized' }, 401);
+    const bundles = db.prepare(
+      "SELECT id, format, read_count, max_reads, created_at, expires_at, size_bytes FROM debug_bundles WHERE expires_at > datetime('now') AND read_count < max_reads ORDER BY created_at DESC"
+    ).all();
+    return json(res, bundles);
+  }
+
+  const debugBundleMatch = url.pathname.match(/^\/api\/debug\/bundle\/([a-f0-9\-]{36})$/);
+  if (debugBundleMatch) {
+    const bundleId = debugBundleMatch[1];
+    if (!req._authUser) return json(res, { error: 'unauthorized' }, 401);
+
+    if (req.method === 'GET') {
+      const bundle = db.prepare('SELECT * FROM debug_bundles WHERE id=?').get(bundleId);
+      if (!bundle) return json(res, { error: 'not found' }, 404);
+      if (bundle.read_count >= bundle.max_reads) {
+        try { fs.unlinkSync(bundle.file_path); } catch {}
+        db.prepare('DELETE FROM debug_bundles WHERE id=?').run(bundleId);
+        return json(res, { error: 'bundle already read (one-time download)' }, 410);
+      }
+      db.prepare('UPDATE debug_bundles SET read_count = read_count + 1 WHERE id=?').run(bundleId);
+      try {
+        const content = fs.readFileSync(bundle.file_path, 'utf8');
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Content-Disposition': `attachment; filename="stoa-debug-${bundleId.slice(0, 8)}.json"`,
+        });
+        res.end(content);
+        if (bundle.read_count + 1 >= bundle.max_reads) {
+          setImmediate(() => {
+            try { fs.unlinkSync(bundle.file_path); } catch {}
+          });
+        }
+      } catch (e) {
+        return json(res, { error: 'bundle file missing' }, 404);
+      }
+      return;
+    }
+
+    if (req.method === 'DELETE') {
+      const bundle = db.prepare('SELECT file_path FROM debug_bundles WHERE id=?').get(bundleId);
+      if (!bundle) return json(res, { error: 'not found' }, 404);
+      try { fs.unlinkSync(bundle.file_path); } catch {}
+      db.prepare('DELETE FROM debug_bundles WHERE id=?').run(bundleId);
+      return json(res, { deleted: true });
     }
   }
 

--- a/stoa.js
+++ b/stoa.js
@@ -3,7 +3,7 @@
 // Human mode:  STOA_TYPE=human node stoa.js [room_id]
 // Agent mode:  STOA_TYPE=ai    STOA_ACTOR_ID=2 node stoa.js
 
-const CLIENT_VERSION = '0.4.208';
+const CLIENT_VERSION = '0.4.209';
 
 const WebSocket = require('ws');
 const readline = require('readline');

--- a/test.js
+++ b/test.js
@@ -4088,6 +4088,72 @@ async function run() {
     assert.strictEqual(r.status, 401);
   });
 
+  // ── R30: Debug share bundle ──
+  console.log('\n[R30: Debug Share Bundle]');
+  let _debugBundleId = null;
+
+  await test('R30 — POST /api/debug/bundle without consent → 400', async () => {
+    const r = await req('POST', '/api/debug/bundle', {});
+    assert.strictEqual(r.status, 400);
+  });
+
+  await test('R30 — POST /api/debug/bundle with consent → creates bundle', async () => {
+    const r = await req('POST', '/api/debug/bundle', { consent: true });
+    assert.strictEqual(r.status, 200);
+    assert.ok(r.body.id);
+    assert.ok(r.body.created_at);
+    assert.ok(r.body.expires_at);
+    assert.ok(r.body.size_bytes > 0);
+    _debugBundleId = r.body.id;
+  });
+
+  await test('R30 — GET /api/debug/bundles — lists active bundles', async () => {
+    const r = await req('GET', '/api/debug/bundles');
+    assert.strictEqual(r.status, 200);
+    assert.ok(Array.isArray(r.body));
+    const found = r.body.find(b => b.id === _debugBundleId);
+    assert.ok(found, 'created bundle should appear in list');
+  });
+
+  await test('R30 — GET /api/debug/bundle/:id — read-once download', async () => {
+    const r = await fetch(`http://${HOST}:${PORT}/api/debug/bundle/${_debugBundleId}`, { headers: { Cookie: sessionCookie } });
+    assert.strictEqual(r.status, 200);
+    const disposition = r.headers.get('content-disposition');
+    assert.ok(disposition && disposition.includes('attachment'));
+    const envelope = await r.json();
+    assert.strictEqual(envelope.format, 1);
+    assert.strictEqual(envelope.redacted, true);
+    assert.ok(envelope.stoa_version);
+    assert.ok(envelope.data);
+    assert.ok(envelope.data.health);
+    assert.ok(envelope.data.counts);
+  });
+
+  await test('R30 — GET /api/debug/bundle/:id again → 410 (already read)', async () => {
+    const r = await fetch(`http://${HOST}:${PORT}/api/debug/bundle/${_debugBundleId}`, { headers: { Cookie: sessionCookie } });
+    assert.strictEqual(r.status, 410);
+  });
+
+  await test('R30 — DELETE /api/debug/bundle/:id — create and delete', async () => {
+    const cr = await req('POST', '/api/debug/bundle', { consent: true });
+    assert.strictEqual(cr.status, 200);
+    const dr = await req('DELETE', `/api/debug/bundle/${cr.body.id}`);
+    assert.strictEqual(dr.status, 200);
+    assert.strictEqual(dr.body.deleted, true);
+    const lr = await req('GET', '/api/debug/bundles');
+    const found = lr.body.find(b => b.id === cr.body.id);
+    assert.ok(!found, 'deleted bundle should not appear in list');
+  });
+
+  await test('R30 — unauthenticated POST /api/debug/bundle → 401', async () => {
+    const r = await fetch(`http://${HOST}:${PORT}/api/debug/bundle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ consent: true }),
+    });
+    assert.strictEqual(r.status, 401);
+  });
+
   // Teardown — delete all test rooms and actors created during the run
   console.log('\n[Test Teardown]');
   await test('Teardown — delete all test rooms', async () => {


### PR DESCRIPTION
## Summary
- Diagnostic snapshot feature in Doctor tab — force-redacted, read-once, auto-delete 24h
- Migration: `debug_bundles` table (UUID id, versioned envelope, read-once semantics)
- Backend: `lib/debug-bundle.js` (collectDiagnostics + forceRedact + buildEnvelope + gcDebugBundles), 4 endpoints (POST create, GET list, GET download, DELETE)
- GC integration in `gcTick()` — piggybacks on existing R18 scheduler
- Frontend: Debug Bundle section in Doctor tab (consent dialog, bundle list, download, delete)
- 7 integration tests, 407/407 pass

## Security
- Force-redact always on: API keys, emails, passwords, IPs, home paths, room titles
- No message content included
- Read-once download (410 on re-read)
- UUID URLs prevent enumeration
- Consent gate required

## Review
- 2 rounds TechLead review, 0 findings final