### PR TITLE
timeout instrumentation: debug-file, smarter watchdog, lower compact threshold

### DIFF
--- a/claude-session.js
+++ b/claude-session.js
@@ -3,6 +3,9 @@
 // No --print flag: process stays alive between turns.
 const { spawn } = require('child_process');
 const { EventEmitter } = require('events');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
 class ClaudeSession extends EventEmitter {
   constructor({ workDir = process.cwd(), flags = [], resumeId = null, env = null } = {}) {
@@ -22,6 +25,9 @@ class ClaudeSession extends EventEmitter {
     this._currentOnTool = null;
     this._accContent = '';
     this._pendingTool = null;
+    // stable debug log path: one file per workdir in os.tmpdir()
+    const wdHash = require('crypto').createHash('sha1').update(workDir).digest('hex').slice(0, 8);
+    this.debugLogPath = path.join(os.tmpdir(), `stoa-claude-${wdHash}.log`);
     this._start();
   }
 
@@ -33,6 +39,7 @@ class ClaudeSession extends EventEmitter {
       '--include-partial-messages',
       '--verbose',
       '--dangerously-skip-permissions',
+      '--debug-file', this.debugLogPath,
       ...this.flags,
     ];
     const spawnOpts = { cwd: this.workDir, windowsHide: true };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.28.4",
+      "version": "0.28.5",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -2149,7 +2149,7 @@ const server = http.createServer(async (req, res) => {
       max_ai_turns: parseInt(process.env.MAX_AI_TURNS) || 5,
       max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 1,
       session_idle_ttl: parseInt(process.env.SESSION_IDLE_TTL) || 5,
-      auto_compact_threshold_kb: parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB) || 500,
+      auto_compact_threshold_kb: parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB) || 300,
       cleanup_cron_hour: parseInt(process.env.CLEANUP_CRON_HOUR) || 10,
       cleanup_max_age_hours: parseInt(process.env.CLEANUP_MAX_AGE_HOURS) || 24, max_pinned_rooms: parseInt(process.env.MAX_PINNED_ROOMS) || 3,
     });
@@ -4076,7 +4076,7 @@ wss.on('connection', (ws, req) => {
         ws.send(JSON.stringify({ type: 'force_update' }));
       }
       ws.send(JSON.stringify({ type: 'agent_ready' }));
-      ws.send(JSON.stringify({ type: 'set_config', max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 1, session_idle_ttl: parseInt(process.env.SESSION_IDLE_TTL) || 5, auto_compact_threshold_kb: parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB) || 500 }));
+      ws.send(JSON.stringify({ type: 'set_config', max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 1, session_idle_ttl: parseInt(process.env.SESSION_IDLE_TTL) || 5, auto_compact_threshold_kb: parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB) || 300 }));
       const connectedActor = db.prepare('SELECT id, name, type, adapter, adapter_config, avatar_color, avatar_symbol, avatar_url, created_at FROM actors WHERE id=?').get(agentActorId);
       if (connectedActor) broadcastGlobal({ type: 'actor_status', actor: { ...connectedActor, online: true, client_version: msg.client_version || null } });
       // R23: push all room settings so agent is always in sync regardless of connect order.

--- a/stoa.js
+++ b/stoa.js
@@ -1074,17 +1074,20 @@ async function processTrigger(msg) {
     // How recently the debug log must have been written for us to consider CLI still active.
     // 60s grace: CLI writes to debug log during API retry backoff, so recent mtime = not hung.
     const DEBUG_ACTIVE_GRACE_MS = 60_000;
+    const MAX_DEBUG_DEFERS = 3;
+    let debugDeferCount = 0;
     const hangWatchdog = setInterval(() => {
       const timeout = fullContent ? TRIGGER_TIMEOUT : FIRST_TOKEN_TIMEOUT;
       if (Date.now() - lastActivity > timeout) {
         // Before aborting, check if CLI is still writing to its debug log — that means
-        // it's retrying the API (backoff), not hung. If so, grant more time.
-        if (session.debugLogPath) {
+        // it's retrying the API (backoff), not hung. If so, grant more time (up to MAX_DEBUG_DEFERS).
+        if (session.debugLogPath && debugDeferCount < MAX_DEBUG_DEFERS) {
           try {
             const { mtimeMs } = fs.statSync(session.debugLogPath);
             if (Date.now() - mtimeMs < DEBUG_ACTIVE_GRACE_MS) {
+              debugDeferCount++;
               lastActivity = Date.now();
-              console.log(`[stoa] watchdog: CLI debug log active ${Math.round((Date.now() - mtimeMs) / 1000)}s ago, resetting timer (API retry?)`);
+              console.log(`[stoa] watchdog: CLI debug log active ${Math.round((Date.now() - mtimeMs) / 1000)}s ago, deferring abort (${debugDeferCount}/${MAX_DEBUG_DEFERS})`);
               return;
             }
           } catch { /* debug log doesn't exist yet — proceed to abort */ }

--- a/stoa.js
+++ b/stoa.js
@@ -154,7 +154,7 @@ const sessionPool = new Map(); // `${workdir}::${room_id}` → ClaudeSession
 const sessionIdleTimers = new Map(); // `${workdir}::${room_id}` → timeout id
 let SESSION_IDLE_TTL = 5; // minutes, configurable via server
 
-let AUTO_COMPACT_THRESHOLD = parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB || '500') * 1024; // KB, configurable
+let AUTO_COMPACT_THRESHOLD = parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB || '300') * 1024; // KB, configurable
 const compactsInFlight = new Set(); // workdir keys currently being compacted — prevents concurrent /compact on same session
 
 // R14: progress-aware compact timeout — resets on any token/state output.
@@ -1071,9 +1071,24 @@ async function processTrigger(msg) {
     sessionRef = session;
     session.on('status', statusHandler);
     const FIRST_TOKEN_TIMEOUT = 10 * 60_000;
+    // How recently the debug log must have been written for us to consider CLI still active.
+    // 60s grace: CLI writes to debug log during API retry backoff, so recent mtime = not hung.
+    const DEBUG_ACTIVE_GRACE_MS = 60_000;
     const hangWatchdog = setInterval(() => {
       const timeout = fullContent ? TRIGGER_TIMEOUT : FIRST_TOKEN_TIMEOUT;
       if (Date.now() - lastActivity > timeout) {
+        // Before aborting, check if CLI is still writing to its debug log — that means
+        // it's retrying the API (backoff), not hung. If so, grant more time.
+        if (session.debugLogPath) {
+          try {
+            const { mtimeMs } = fs.statSync(session.debugLogPath);
+            if (Date.now() - mtimeMs < DEBUG_ACTIVE_GRACE_MS) {
+              lastActivity = Date.now();
+              console.log(`[stoa] watchdog: CLI debug log active ${Math.round((Date.now() - mtimeMs) / 1000)}s ago, resetting timer (API retry?)`);
+              return;
+            }
+          } catch { /* debug log doesn't exist yet — proceed to abort */ }
+        }
         clearInterval(hangWatchdog);
         abortReason = 'timeout';
         console.error(`[stoa] trigger timeout (${timeout/1000}s ${fullContent ? 'idle' : 'no first token'}), aborting`);


### PR DESCRIPTION
## Summary
- **`--debug-file`**: spawn CLI dengan flag `--debug-file <tmpdir>/stoa-claude-<hash>.log` agar kita bisa tahu apa yang CLI lakukan saat diam
- **Smarter watchdog**: sebelum abort karena timeout, cek apakah debug log diupdate <60s terakhir — kalau iya, CLI masih aktif (API retry/backoff), reset timer, jangan kill
- **Lower compact threshold**: default auto-compact turun dari 500KB → 300KB (dan sync ke server.js) supaya sesi tidak terlalu besar sebelum compact

## Root cause yang diatasi
CLI 2.1.x tidak emit event apa pun ke stream-json saat retry API. Dari sisi stoa.js, "API sedang retry" dan "proses hang" terlihat identik. Debug log memberikan sinyal ke watchdog tanpa mengubah protocol CLI.

## Test plan
- [ ] 407 tests pass (0 failed)
- [ ] Cek `ls /tmp/stoa-claude-*.log` setelah agent pertama kali trigger — file harus ada
- [ ] Lihat `logs/stoa.log` kalau ada timeout: harus ada log "watchdog: CLI debug log active Xs ago, resetting timer" sebelum abort yang sesungguhnya