### PR TITLE
threads fase 3b: behavioral switch threading

### DIFF
--- a/server.js
+++ b/server.js
@@ -2239,7 +2239,7 @@ const server = http.createServer(async (req, res) => {
       port:        PORT,
       human_name_from_env: !!process.env.HUMAN_NAME,
       max_ai_turns: parseInt(process.env.MAX_AI_TURNS) || 5,
-      max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 1,
+      max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 3,
       session_idle_ttl: parseInt(process.env.SESSION_IDLE_TTL) || 5,
       auto_compact_threshold_kb: parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB) || 300,
       cleanup_cron_hour: parseInt(process.env.CLEANUP_CRON_HOUR) || 10,
@@ -4248,7 +4248,7 @@ wss.on('connection', (ws, req) => {
         ws.send(JSON.stringify({ type: 'force_update' }));
       }
       ws.send(JSON.stringify({ type: 'agent_ready' }));
-      ws.send(JSON.stringify({ type: 'set_config', max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 1, session_idle_ttl: parseInt(process.env.SESSION_IDLE_TTL) || 5, auto_compact_threshold_kb: parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB) || 300 }));
+      ws.send(JSON.stringify({ type: 'set_config', max_concurrent: parseInt(process.env.MAX_CONCURRENT) || 3, session_idle_ttl: parseInt(process.env.SESSION_IDLE_TTL) || 5, auto_compact_threshold_kb: parseInt(process.env.AUTO_COMPACT_THRESHOLD_KB) || 300 }));
       const connectedActor = db.prepare('SELECT id, name, type, adapter, adapter_config, avatar_color, avatar_symbol, avatar_url, created_at FROM actors WHERE id=?').get(agentActorId);
       if (connectedActor) broadcastGlobal({ type: 'actor_status', actor: { ...connectedActor, online: true, client_version: msg.client_version || null } });
       // R23: push all room settings so agent is always in sync regardless of connect order.
@@ -5570,7 +5570,7 @@ async function handleHumanMessage(roomId, content, attachments, replyTo, senderW
       const agentIds = db.prepare("SELECT a.id FROM room_participants rp JOIN actors a ON a.id=rp.actor_id WHERE rp.room_id=? AND a.type='ai'").all(roomId).map(r => r.id);
       for (const aId of agentIds) {
         const aw = agentClients.get(aId);
-        if (aw?.readyState === 1) aw.send(JSON.stringify({ type: 'steer_message', room_id: roomId, content, message_id: messageId }));
+        if (aw?.readyState === 1) aw.send(JSON.stringify({ type: 'steer_message', room_id: roomId, thread_id: threadId || null, content, message_id: messageId }));
       }
       return;
     }
@@ -6361,23 +6361,6 @@ server.listen(PORT, () => {
   try { drainPendingWakesOnStartup(); } catch (e) { console.error('[wake] startup drain failed:', e.message); }
 });
 
-function waitForRoomIdle(roomId, timeoutMs = 300000) {
-  return new Promise(resolve => {
-    if (!activeSequences.has(roomId)) return resolve();
-    const onIdle = (id) => {
-      if (id !== roomId) return;
-      roomIdleBus.removeListener('idle', onIdle);
-      clearTimeout(timer);
-      resolve();
-    };
-    const timer = setTimeout(() => {
-      roomIdleBus.removeListener('idle', onIdle);
-      console.warn(`[queue] room ${roomId} idle timeout after ${timeoutMs}ms`);
-      resolve();
-    }, timeoutMs);
-    roomIdleBus.on('idle', onIdle);
-  });
-}
 
 function extractSlackFullText(event) {
   const parts = [];

--- a/test.js
+++ b/test.js
@@ -4497,6 +4497,28 @@ async function run() {
     assert.strictEqual(r.status, 401);
   });
 
+  // Fase 3b: behavioral switch
+  console.log('\n[Fase 3b: Behavioral Switch]');
+
+  await test('Fase3b — max_concurrent fallback default is 3 (code check)', async () => {
+    const src = require('fs').readFileSync(require('path').join(__dirname, 'server.js'), 'utf8');
+    const settingsLine = src.split('\n').find(l => l.includes('max_concurrent:') && l.includes('MAX_CONCURRENT'));
+    assert.ok(settingsLine, 'max_concurrent settings line not found');
+    assert.ok(settingsLine.includes('|| 3'), 'max_concurrent default should be 3, not 1');
+  });
+
+  await test('Fase3b — waitForRoomIdle removed (dead code)', async () => {
+    const src = require('fs').readFileSync(require('path').join(__dirname, 'server.js'), 'utf8');
+    assert.ok(!src.includes('function waitForRoomIdle'), 'waitForRoomIdle should be removed');
+  });
+
+  await test('Fase3b — steer_message includes thread_id field', async () => {
+    const src = require('fs').readFileSync(require('path').join(__dirname, 'server.js'), 'utf8');
+    const steerLine = src.split('\n').find(l => l.includes("type: 'steer_message'"));
+    assert.ok(steerLine, 'steer_message line not found');
+    assert.ok(steerLine.includes('thread_id'), 'steer_message must include thread_id');
+  });
+
   await test('Thread — cleanup', async () => {
     // Cleaned up in teardown
   });


### PR DESCRIPTION
## Summary
- `max_concurrent` default changed from 1 to 3 — agents can now run 3 parallel sessions (threads)
- Removed dead `waitForRoomIdle` function (defined but never called since automation uses `automationQueue`)
- Added `thread_id` to `steer_message` WS payload — steer messages now correctly scoped per thread (agent stoa.js keys steer by `${room_id}:${thread_id||0}`)
- 3 new tests for behavioral switch validation

## Context
Fase 3b per `threads-refactor-plan.md` §6. This is the behavioral switch that enables real thread parallelism — separated from Fase 3a (UI) so regressions can be isolated per PR.

## Test plan
- [x] 440/440 tests pass
- [x] `waitForRoomIdle` confirmed removed from source
- [x] `steer_message` confirmed includes `thread_id`
- [x] `max_concurrent` default confirmed as 3 in all code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)