### PR TITLE
fix migration nested transaction error

### DIFF
--- a/migrations/20260610-backfill-automation-connection-id.sql
+++ b/migrations/20260610-backfill-automation-connection-id.sql
@@ -1,8 +1,6 @@
 -- Backfill connection_id for automations that have NULL connection_id
 -- Assigns them to the first (lowest id) connection in automation_connections
-BEGIN;
 UPDATE automations
 SET connection_id = (SELECT MIN(id) FROM automation_connections)
 WHERE connection_id IS NULL
   AND EXISTS (SELECT 1 FROM automation_connections);
-COMMIT;

--- a/migrations/20260904-r28-busy-input-mode.sql
+++ b/migrations/20260904-r28-busy-input-mode.sql
@@ -1,5 +1,3 @@
-BEGIN;
-
 CREATE TABLE IF NOT EXISTS room_message_queue (
   id          INTEGER PRIMARY KEY AUTOINCREMENT,
   room_id     INTEGER NOT NULL REFERENCES rooms(id) ON DELETE CASCADE,
@@ -12,5 +10,3 @@ CREATE TABLE IF NOT EXISTS room_message_queue (
 );
 
 CREATE INDEX IF NOT EXISTS idx_rmq_room ON room_message_queue(room_id, position);
-
-COMMIT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stoa",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stoa",
-      "version": "0.36.0",
+      "version": "0.36.1",
       "license": "ISC",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stoa",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Migration runner (`server.js:631-634`) already wraps each migration with `BEGIN TRANSACTION`/`COMMIT`
- Two migration files had their own `BEGIN;`/`COMMIT;` inside, causing SQLite error: "cannot start a transaction within a transaction"
- Removed redundant `BEGIN;`/`COMMIT;` from:
  - `migrations/20260610-backfill-automation-connection-id.sql`
  - `migrations/20260904-r28-busy-input-mode.sql`

## Test plan
- [ ] Restart server — migration `20260904-r28-busy-input-mode.sql` should apply successfully
- [ ] Verify `room_message_queue` table exists after restart
- [ ] Confirm no "cannot start a transaction within a transaction" errors in logs